### PR TITLE
Fix EZP-28967: RichText FieldType removes line breaks inside table cells

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -358,6 +358,12 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="docbook:th/text()">
+    <xsl:call-template name="breakLine">
+      <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+
   <xsl:template match="docbook:th">
     <xsl:element name="th" namespace="{$outputNamespace}">
       <xsl:if test="@class">
@@ -419,6 +425,12 @@
       </xsl:if>
       <xsl:apply-templates/>
     </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="docbook:td/text()">
+    <xsl:call-template name="breakLine">
+      <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
   </xsl:template>
 
   <xsl:template match="docbook:td">

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -365,6 +365,12 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="docbook:th/text()">
+    <xsl:call-template name="breakLine">
+      <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+
   <xsl:template match="docbook:th">
     <xsl:element name="th" namespace="{$outputNamespace}">
       <xsl:if test="@class">
@@ -426,6 +432,12 @@
       </xsl:if>
       <xsl:apply-templates/>
     </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="docbook:td/text()">
+    <xsl:call-template name="breakLine">
+      <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
   </xsl:template>
 
   <xsl:template match="docbook:td">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -437,7 +437,9 @@
           <xsl:value-of select="@scope"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:apply-templates/>
+      <xsl:call-template name="breakline">
+       <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
     </th>
   </xsl:template>
 
@@ -491,7 +493,9 @@
           <xsl:value-of select="@rowspan"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:apply-templates/>
+      <xsl:call-template name="breakline">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
     </td>
   </xsl:template>
 

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/018-htmlTable.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/018-htmlTable.xml
@@ -8,11 +8,13 @@
     <caption>Table caption.</caption>
     <tbody>
       <tr class="rowClass1">
-        <th class="headingClass1" ezxhtml:width="102" valign="top" colspan="1" rowspan="5" abbr="XSLT" scope="col">11</th>
+        <th class="headingClass1" ezxhtml:width="102" valign="top" colspan="1" rowspan="5" abbr="XSLT" scope="col">11
+with some line break</th>
         <th class="headingClass2" ezxhtml:width="37%" valign="middle" colspan="2" rowspan="6" abbr="XSD" scope="row">12</th>
       </tr>
       <tr class="rowClass2">
-        <td class="cellClass1" ezxhtml:width="74%" valign="bottom" colspan="3" rowspan="7">21</td>
+        <td class="cellClass1" ezxhtml:width="74%" valign="bottom" colspan="3" rowspan="7">21
+with some line break</td>
         <td class="cellClass2" ezxhtml:width="38" valign="baseline" colspan="4" rowspan="8">22</td>
       </tr>
     </tbody>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/018-htmlTable.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/018-htmlTable.xml
@@ -4,11 +4,11 @@
     <caption>Table caption.</caption>
     <tbody>
       <tr class="rowClass1">
-        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
+        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11<br/>with some line break</th>
         <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
       </tr>
       <tr class="rowClass2">
-        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">21</td>
+        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">21<br/>with some line break</td>
         <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">22</td>
       </tr>
     </tbody>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/018-htmlTable.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/018-htmlTable.xml
@@ -4,11 +4,11 @@
     <caption>Table caption.</caption>
     <tbody>
       <tr class="rowClass1">
-        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
+        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11<br/>with some line break</th>
         <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
       </tr>
       <tr class="rowClass2">
-        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">21</td>
+        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">21<br/>with some line break</td>
         <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">22</td>
       </tr>
     </tbody>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28967](https://jira.ez.no/browse/EZP-28967)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Description from JIRA:
>In RichText Editor, you can create line breaks (inside a paragraph) by pressing Shift + Enter. 
If you create a table using the rich text field type and type some text in a table cell then add a line break and then add some more text after saving the line break is removed.
If you add a new paragraph in the table cell by pressing Enter then delete the second line with Backspace and then you do the text + line break + text as I've written in the previous line the line break is kept.
It seems like that line breaks are kept only if they are inside a paragraph (p tag) in a table cell.

This PR contains a fix for ignored `<br />` tags inside `<td>` and `<th>` tags of the table in RichText FieldType.

## Steps to reproduce:
>1. Create a table in a rich text field.
>2. Click in a table cell
>3. Type "first line", press Shift+Enter, type "second line"
>4. Publish the content
>5. View / edit the content, no br tag between "first line" and "second line"

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.

This is a followup PR for https://github.com/ezsystems/ezpublish-kernel/pull/2301.