### PR TITLE
EZP-28009: Changed priority of kernel pass to avoid dealing with tags

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/KernelRichTextPass.php
+++ b/src/bundle/DependencyInjection/Compiler/KernelRichTextPass.php
@@ -10,7 +10,6 @@ namespace EzSystems\EzPlatformRichTextBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Handles compatibility with kernel 7.x.
@@ -36,25 +35,5 @@ class KernelRichTextPass implements CompilerPassInterface
             },
             $this->servicesToRemove
         );
-
-        $def = $container->getDefinition('ezpublish.persistence.legacy.field_value_converter.registry');
-        $methodCalls = [];
-        foreach ($def->getMethodCalls() as $methodCall) {
-            if ($methodCall[0] != 'register') {
-                $methodCalls[] = $methodCall;
-                continue;
-            }
-
-            if ($methodCall[1][0] != 'ezrichtext') {
-                $methodCalls[] = $methodCall;
-                continue;
-            }
-
-            if (!$methodCall[1][1] instanceof Reference || (string)$methodCall[1][1] !== 'ezpublish.fieldType.ezrichtext.converter') {
-                $methodCalls[] = $methodCall;
-                continue;
-            }
-        }
-        $def->setMethodCalls($methodCalls);
     }
 }

--- a/src/bundle/EzPlatformRichTextBundle.php
+++ b/src/bundle/EzPlatformRichTextBundle.php
@@ -13,6 +13,7 @@ use EzSystems\EzPlatformRichTextBundle\DependencyInjection\Compiler\KernelRichTe
 use EzSystems\EzPlatformRichTextBundle\DependencyInjection\Compiler\RichTextHtml5ConverterPass;
 use EzSystems\EzPlatformRichTextBundle\DependencyInjection\Configuration\Parser\FieldType\RichText;
 use EzSystems\EzPlatformRichTextBundle\DependencyInjection\EzPlatformRichTextExtension;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,11 +22,16 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class EzPlatformRichTextBundle extends Bundle
 {
+    /**
+     * The kernel pass must execute BEFORE the ones from kernel that register tagged services.
+     */
+    const KERNEL_PASS_PRIORITY = 30;
+
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
         $container->addCompilerPass(new RichTextHtml5ConverterPass());
-        $container->addCompilerPass(new KernelRichTextPass());
+        $container->addCompilerPass(new KernelRichTextPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, self::KERNEL_PASS_PRIORITY);
         $this->registerConfigParser($container);
     }
 


### PR DESCRIPTION
By deleting kernel services before their tags are processed, we don't need to remove them from the services they're added to as parameters.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | None
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Increases the priority of the kernel pass. Ensures that services we remove haven't been processed for tags, and haven't been injected into other services as arguments.

Fixes the problems reported by QA on ezsystems/ezpublish-kernel#2302.