### PR TITLE
[WiP] Applied changes from Kernel since extracting RichText

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -26,8 +26,4 @@ if (!($settings = include(__DIR__ . '/config.php'))) {
     throw new \RuntimeException('Could not read config.php, please copy config.php-DEVELOPMENT to config.php & customize to your needs!');
 }
 
-// Class alias used for BC
-// Enables old code which still extends non namespaced TestCase to work
-class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
-
 require_once __DIR__ . '/vendor/autoload.php';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,9 +11,7 @@
   <testsuites>
     <testsuite name="ezrichtext_field_type">
       <directory>tests/lib</directory>
-      <exclude>
-        <directory>tests/lib/eZ/API</directory>
-      </exclude>
+      <exclude>tests/lib/eZ/API</exclude>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -22,6 +22,7 @@
       </a:documentation>
       <ref name="db.title"/>
     </define>
+
     <define name="db.blockquote.info" combine="choice">
       <a:documentation>
         Needed by the LIBXML engine to allow for multiple title elements on the same level below blockquote
@@ -29,6 +30,26 @@
       <optional>
         <ref name="db.title"/>
       </optional>
+    </define>
+
+    <define name="db.superscript.attlist" combine="interleave">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="db.emphasis"/>
+          <ref name="db.link"/>
+        </choice>
+      </zeroOrMore>
+    </define>
+
+    <define name="db.subscript.attlist" combine="interleave">
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="db.emphasis"/>
+          <ref name="db.link"/>
+        </choice>
+      </zeroOrMore>
     </define>
 
     <define name="db.orderedlist">

--- a/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -22,6 +22,15 @@
       </a:documentation>
       <ref name="db.title"/>
     </define>
+    <define name="db.blockquote.info" combine="choice">
+      <a:documentation>
+        Needed by the LIBXML engine to allow for multiple title elements on the same level below blockquote
+      </a:documentation>
+      <optional>
+        <ref name="db.title"/>
+      </optional>
+    </define>
+
     <define name="db.orderedlist">
       <element name="orderedlist">
         <a:documentation>A list in which each entry is marked with a sequentially incremented label</a:documentation>

--- a/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
@@ -248,7 +248,7 @@ class TemplateTest extends TestCase
  <section xmlns="http://docbook.org/ns/docbook" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
   <eztemplate name="custom_tag" ezxhtml:align="right">
     <ezcontent>
-      <para>param: value</para>
+      <para>Param: value</para>
     </ezcontent>
     <ezconfig>
       <ezvalue key="param">value</ezvalue>

--- a/tests/lib/eZ/RichText/Validator/DocbookTest.php
+++ b/tests/lib/eZ/RichText/Validator/DocbookTest.php
@@ -76,6 +76,44 @@ class DocbookTest extends TestCase
 ',
                 [],
             ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+    xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>test
+        <superscript>1
+            <emphasis role="strong">bold</emphasis>
+            <emphasis>italic</emphasis>
+            <emphasis role="underlined">underline</emphasis> superscript
+            <link xlink:href="http://ez.no" xlink:show="none" xlink:title="link tile">link</link>
+            <emphasis role="strikedthrough">strikedthrough</emphasis>
+        </superscript>
+    </para>
+</section>',
+                [],
+            ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+    xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>test
+        <subscript>1
+            <emphasis role="strong">bold</emphasis>
+            <emphasis>italic</emphasis>
+            <emphasis role="underlined">underline</emphasis> subscript
+            <link xlink:href="http://ez.no" xlink:show="none" xlink:title="link tile">link</link>
+            <emphasis role="strikedthrough">strikedthrough</emphasis>
+        </subscript>
+    </para>
+</section>',
+                [],
+            ],
         ];
     }
 

--- a/tests/lib/eZ/RichText/Validator/DocbookTest.php
+++ b/tests/lib/eZ/RichText/Validator/DocbookTest.php
@@ -5,12 +5,6 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);
-/**
- * File containing the Docbook validation test.
- *
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
- * @license For full copyright and license information view LICENSE file distributed with this source code.
- */
 
 namespace EzSystems\Tests\EzPlatformRichText\eZ\RichText\Validator;
 
@@ -59,6 +53,25 @@ class DocbookTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
     <para ezxhtml:class="">Nada Surf - Happy Kid</para>
+</section>
+',
+                [],
+            ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <blockquote>
+    <para>Some comments to people\'s comments!</para>
+  </blockquote>
+  <blockquote>
+    <title ezxhtml:level="3">Header level 3</title>
+    <title ezxhtml:level="4">Header level 4</title>
+    <para>foobar quote<link xlink:href="ezurl://1044" xlink:show="none">http://ez.no</link> for more info.</para>
+  </blockquote>
 </section>
 ',
                 [],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Part of [EZP-28009](https://jira.ez.no/browse/EZP-28009)

This PR shows changes to RichText FieldType that happened since it was extracted at ezsystems/ezpublish-kernel@ab3855d7d1f99959849bd2da81452d60a36144f6.

Changes include:
- [x] ezsystems/ezpublish-kernel#2386
- [x] ezsystems/ezpublish-kernel#2381
- [x] ezsystems/ezpublish-kernel#2351
- [ ] Custom Styles
