### PR TITLE
EZP-28009: Fixed loading default RichText core settings

### DIFF
--- a/src/bundle/DependencyInjection/EzPlatformRichTextExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformRichTextExtension.php
@@ -51,7 +51,6 @@ class EzPlatformRichTextExtension extends Extension implements PrependExtensionI
             $container,
             new FileLocator(__DIR__ . '/../Resources/config')
         );
-        $loader->load('default_settings.yml');
         $loader->load('fieldtype_services.yml');
         $loader->load('rest.yml');
         $loader->load('templating.yml');

--- a/src/bundle/EzPlatformRichTextBundle.php
+++ b/src/bundle/EzPlatformRichTextBundle.php
@@ -30,6 +30,11 @@ class EzPlatformRichTextBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
+
+        /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $core */
+        $core = $container->getExtension('ezpublish');
+        $core->addDefaultSettings(__DIR__ . '/Resources/config', ['default_settings.yml']);
+
         $container->addCompilerPass(new RichTextHtml5ConverterPass());
         $container->addCompilerPass(new KernelRichTextPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, self::KERNEL_PASS_PRIORITY);
         $this->registerConfigParser($container);

--- a/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -12,6 +12,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
 use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser\AbstractParserTestCase;
 use EzSystems\EzPlatformRichTextBundle\DependencyInjection\Configuration\Parser\FieldType\RichText as RichTextConfigParser;
 use EzSystems\EzPlatformRichTextBundle\DependencyInjection\EzPlatformRichTextExtension;
+use EzSystems\EzPlatformRichTextBundle\EzPlatformRichTextBundle;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -53,6 +54,9 @@ class RichTextTest extends AbstractParserTestCase
      */
     protected function load(array $configurationValues = [])
     {
+        $bundle = new EzPlatformRichTextBundle();
+        $bundle->build($this->container);
+
         // mock list of available bundles
         $this->setParameter(
             'kernel.bundles',
@@ -193,8 +197,7 @@ class RichTextTest extends AbstractParserTestCase
                 [
                     'fieldtypes.ezrichtext.output_custom_xsl' => [
                         // Default settings will be added
-                        // @todo replace with ezplatform-richtext file once ezpublish extension can detect that
-                        ['path' => '%kernel.root_dir%/../vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl', 'priority' => 0],
+                        ['path' => '%kernel.root_dir%/../vendor/ezsystems/ezplatform-richtext/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl', 'priority' => 0],
                         ['path' => '/foo/bar.xsl', 'priority' => 123],
                         ['path' => '/foo/custom.xsl', 'priority' => -10],
                         ['path' => '/another/custom.xsl', 'priority' => 27],
@@ -216,8 +219,7 @@ class RichTextTest extends AbstractParserTestCase
                 [
                     'fieldtypes.ezrichtext.edit_custom_xsl' => [
                         // Default settings will be added
-                        // @todo replace with ezplatform-richtext file once ezpublish extension can detect that
-                        ['path' => '%kernel.root_dir%/../vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl', 'priority' => 0],
+                        ['path' => '%kernel.root_dir%/../vendor/ezsystems/ezplatform-richtext/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl', 'priority' => 0],
                         ['path' => '/foo/bar.xsl', 'priority' => 123],
                         ['path' => '/foo/custom.xsl', 'priority' => -10],
                         ['path' => '/another/custom.xsl', 'priority' => 27],

--- a/tests/integration/eZ/API/SetupFactory/LegacySetupFactory.php
+++ b/tests/integration/eZ/API/SetupFactory/LegacySetupFactory.php
@@ -57,7 +57,7 @@ class LegacySetupFactory extends CoreLegacySetupFactory
     {
         parent::externalBuildContainer($containerBuilder);
 
-        $this->loadRichTextSettings($containerBuilder);
         $this->loadCoreSettings($containerBuilder);
+        $this->loadRichTextSettings($containerBuilder);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Related to [EZP-28009](https://jira.ez.no/browse/EZP-28009)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.0 (master)`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes loading of default (core) settings related to RichText package.
Loading should be done by API provided via CoreExtension (`ezpublish`) instead of RichTextExtension (`ezrichtext`).

**TODO**:
- [x] Fix a bug.
- [x] Fix tests.
- [x] Wait for Travis to confirm.
