### PR TITLE
EZP-28009: Changed eZ Platform branch for Behat tests to master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
     },
     "extra": {
-        "_ezplatform_branch_for_behat_tests": "ezp-28009-enable-richtext-bundle",
+        "_ezplatform_branch_for_behat_tests": "master",
         "branch-alias": {
             "dev-tmp_ci_branch": "1.0.x-dev",
             "dev-master": "1.0.x-dev"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow-up to [EZP-28009](https://jira.ez.no/browse/EZP-28009) and #11 
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.0 (master)`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Since ezsystems/ezplatform#337 has been merged a while ago, `_ezplatform_branch_for_behat_tests` can be safely changed back to `master`.

**TODO**:
- [x] Switch branch for Behat tests back to master

