### PR TITLE
[Twig] Moved RichTextExtension class to the Bundle namespace

### DIFF
--- a/src/bundle/Resources/config/templating.yml
+++ b/src/bundle/Resources/config/templating.yml
@@ -1,5 +1,5 @@
 services:
-    EzSystems\EzPlatformRichText\Templating\Twig\Extension\RichTextExtension:
+    EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension\RichTextExtension:
         arguments:
             - '@ezrichtext.converter.output.xhtml5'
             - '@ezrichtext.converter.edit.xhtml5'

--- a/src/bundle/Templating/Twig/Extension/RichTextExtension.php
+++ b/src/bundle/Templating/Twig/Extension/RichTextExtension.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace EzSystems\EzPlatformRichText\Templating\Twig\Extension;
+namespace EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension;
 
 use EzSystems\EzPlatformRichText\eZ\RichText\Converter as RichTextConverterInterface;
 use Twig_Extension;
@@ -15,12 +15,12 @@ use Twig_SimpleFilter;
 class RichTextExtension extends Twig_Extension
 {
     /**
-     * @var RichTextConverterInterface
+     * @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter
      */
     private $richTextConverter;
 
     /**
-     * @var RichTextConverterInterface
+     * @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter
      */
     private $richTextEditConverter;
 


### PR DESCRIPTION
This PR moves Twig Extension for RichText to the Bundle namespace where it belongs.
Extension is exposed via Symfony DIC tag, so there are no BC concerns - it works as previously.

**TODO**:
- [x] Move `RichTextExtension` to the Bundle namespace.
