### PR TITLE
EZP-29887: Dropped defining default embed-inline View type

### DIFF
--- a/src/bundle/Resources/config/prepend/ezpublish.yml
+++ b/src/bundle/Resources/config/prepend/ezpublish.yml
@@ -7,9 +7,3 @@ system:
         fielddefinition_settings_templates:
             -   template: '@EzPlatformRichText/RichText/fielddefinition_settings.html.twig'
                 priority: 0
-
-        content_view:
-            embed-inline:
-                default:
-                    template: '@ezdesign/content_view/embed_inline.html.twig'
-                    match: []

--- a/src/bundle/Resources/views/themes/standard/content_view/embed_inline.html.twig
+++ b/src/bundle/Resources/views/themes/standard/content_view/embed_inline.html.twig
@@ -1,5 +1,0 @@
-{% if location is defined %}
-    <a href="{{ path(location) }}">{{ content.name }}</a>
-{% else %}
-    <a href="{{ path( "ez_urlalias", {"contentId": content.id} ) }}">{{ content.name }}</a>
-{% endif %}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29887](https://jira.ez.no/browse/EZP-29887)
| **Requires** | ezsystems/ezpublish-kernel#2503
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.0 for eZ Platform 2.4`
| **BC breaks**      | no
| **Tests pass**     | no, not related failure
| **Doc needed**     | no

Default view templates should be provided by ezpublish-kernel (see ezsystems/ezpublish-kernel#2503).
Defining it here makes it impossible to override by a project, due to order of merging of arrays with SA-aware config.

**TODO**:
- [x] Fix a bug.
- [ ] Fix failing unrelated tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
