### PR TITLE
Add missing BC alias for external storage

### DIFF
--- a/src/bundle/Resources/config/bc/aliases.yml
+++ b/src/bundle/Resources/config/bc/aliases.yml
@@ -3,6 +3,9 @@ services:
     ezpublish.fieldType.ezrichtext:
         alias: EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Type
 
+    ezpublish.fieldType.ezrichtext.externalStorage:
+        alias: EzSystems\EzPlatformRichText\eZ\FieldType\RichText\RichTextStorage
+
     ezpublish.fieldType.ezrichtext.converter:
         alias: EzSystems\EzPlatformRichText\eZ\Persistence\Legacy\RichTextFieldValueConverter
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30012](https://jira.ez.no/browse/EZP-30012)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

`ezpublish.fieldType.ezrichtext.externalStorage` service is missing a BC layer, which is used in https://github.com/netgen/NetgenRichTextDataTypeBundle .

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
