### PR TITLE
EZP-29927: Content Type translation not used on RichText fields

### DIFF
--- a/src/lib/Form/Mapper/RichTextFormMapper.php
+++ b/src/lib/Form/Mapper/RichTextFormMapper.php
@@ -20,15 +20,13 @@ class RichTextFormMapper implements FieldValueFormMapperInterface
     {
         $fieldDefinition = $data->fieldDefinition;
         $formConfig = $fieldForm->getConfig();
-        $names = $fieldDefinition->getNames();
-        $label = $fieldDefinition->getName($formConfig->getOption('mainLanguageCode')) ?: reset($names);
 
         $fieldForm
             ->add(
                 $formConfig->getFormFactory()->createBuilder()
                     ->create('value', RichTextFieldType::class, [
                         'required' => $fieldDefinition->isRequired,
-                        'label' => $label,
+                        'label' => $fieldDefinition->getName(),
                     ])
                     ->setAutoInitialize(false)
                     ->getForm()


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29927](https://jira.ez.no/browse/EZP-29927)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.0 (for eZ Platform 2.4)`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes `RichTextFormMapper`, so translated Content Type label is visible in Create and Edit modes for RichText fields.

The fix is almost exactly the same as [the one done for repository-forms](https://github.com/ezsystems/repository-forms/pull/267/files#diff-ce34bcdffd1e219bcdb9a9cc9034d6bf). It didn't work because we've overridden the `RichTextFormMapper` in this package.


**TODO**:
- [X] Fix a bug..
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
