### PR TITLE
EZP-30319: Fixed ezrichtext.style.namespace parameter usage

### DIFF
--- a/src/bundle/Resources/config/fieldtype_services.yml
+++ b/src/bundle/Resources/config/fieldtype_services.yml
@@ -38,7 +38,7 @@ services:
             - '@ezpublish.config.resolver'
             - '@templating'
             - '%ezrichtext.tag.namespace%'
-            - '%ezrichtext.style.namespace'
+            - '%ezrichtext.style.namespace%'
             - '%ezrichtext.embed.namespace%'
             - '@?logger'
             - '%ezplatform.ezrichtext.custom_tags%'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30319](https://jira.ez.no/browse/EZP-30319)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.0 for eZ Platform 2.4.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

We were trying to implement default templates for `block`/`inline` custom styles. Found them here, and debugged why they were not working properly.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
