### PR TITLE
EZP-30166 :  RichText Link converter emits warning during custom tag conversion

### DIFF
--- a/src/lib/eZ/RichText/Converter/Link.php
+++ b/src/lib/eZ/RichText/Converter/Link.php
@@ -58,8 +58,11 @@ class Link implements Converter
     public function convert(DOMDocument $document)
     {
         $document = clone $document;
+
         $xpath = new DOMXPath($document);
         $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
+        $xpath->registerNamespace('xlink', 'http://www.w3.org/1999/xlink');
+
         $linkAttributeExpression = "starts-with( @xlink:href, 'ezlocation://' ) or starts-with( @xlink:href, 'ezcontent://' )";
         $xpathExpression = "//docbook:link[{$linkAttributeExpression}]|//docbook:ezlink";
 

--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -186,6 +186,9 @@ class Template extends Render implements Converter
     {
         $innerDoc = new DOMDocument();
 
+        $rootNode = $innerDoc->createElementNS('http://docbook.org/ns/docbook', 'section');
+        $innerDoc->appendChild($rootNode);
+
         /** @var \DOMNode $child */
         foreach ($node->childNodes as $child) {
             $newNode = $innerDoc->importNode($child, true);
@@ -194,12 +197,11 @@ class Template extends Render implements Converter
                     "Failed to import Custom Style content of node '{$child->getNodePath()}'"
                 );
             }
-            $innerDoc->appendChild($newNode);
+
+            $rootNode->appendChild($newNode);
         }
 
-        $convertedInnerDoc = $this->richTextConverter->convert($innerDoc);
-
-        return trim($convertedInnerDoc->saveHTML());
+        return trim($this->richTextConverter->convert($innerDoc)->saveHTML());
     }
 
     /**

--- a/tests/lib/eZ/RichText/Converter/AggregateTest.php
+++ b/tests/lib/eZ/RichText/Converter/AggregateTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformRichText\eZ\RichText\Converter;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
+use EzSystems\EzPlatformRichText\eZ\RichText\Converter\Aggregate;
+use EzSystems\EzPlatformRichText\eZ\RichText\Converter\Link;
+use EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render\Template;
+use EzSystems\EzPlatformRichText\eZ\RichText\RendererInterface;
+use PHPUnit\Framework\TestCase;
+
+class AggregateTest extends TestCase
+{
+    /**
+     * @param $input
+     * @param $expectedWarningMessage
+     *
+     * @dataProvider providerConvertWithLinkInCustomTag
+     *
+     * @see https://jira.ez.no/browse/EZP-30166
+     */
+    public function testConvertWithLinkInCustomTag(
+        $input,
+        $expectedOutput
+    ) {
+        $xmlDocument = new \DOMDocument();
+        $xmlDocument->loadXML($input);
+
+        $locationService = $this->createMock(LocationService::class);
+        $contentService = $this->createMock(ContentService::class);
+        $urlAliasRouter = $this->createMock(UrlAliasRouter::class);
+        $renderer = $this->createMock(RendererInterface::class);
+
+        $linkConverter = new Link(
+            $locationService,
+            $contentService,
+            $urlAliasRouter
+        );
+
+        $aggregate = new Aggregate([$linkConverter]);
+
+        $templateConverter = new Template(
+            $renderer,
+            $aggregate
+        );
+
+        $aggregate = new Aggregate([$templateConverter, $linkConverter]);
+        $output = $aggregate->convert($xmlDocument);
+
+        $expectedOutputDocument = new \DOMDocument();
+        $expectedOutputDocument->loadXML($expectedOutput);
+        $this->assertEquals($expectedOutputDocument, $output, 'Xml is not converted as expected');
+    }
+
+    public function providerConvertWithLinkInCustomTag(): array
+    {
+        return [
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+    <para></para>
+    <eztemplate name="bulbo" ezxhtml:class="ez-custom-tag ez-custom-tag--attributes-visible">
+        <ezcontent>
+            <para>Just a regular text</para>
+            <para>
+                <link xlink:href="ezlocation://2" xlink:show="none">ezlocation URL</link>
+            </para>
+            <para>
+                <link xlink:href="ezurl://1" xlink:show="none" xlink:title="">ezurl URL </link>
+            </para>
+        </ezcontent>
+        <ezconfig><ezvalue key="title">Bulbo</ezvalue></ezconfig>
+    </eztemplate>
+</section>',
+                '<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para/>
+    <eztemplate name="bulbo" ezxhtml:class="ez-custom-tag ez-custom-tag--attributes-visible">
+        <ezcontent>
+            <para>Just a regular text</para>
+            <para>
+                <link xlink:href="" xlink:show="none">ezlocation URL</link>
+            </para>
+            <para>
+                <link xlink:href="ezurl://1" xlink:show="none" xlink:title="">ezurl URL </link>
+            </para>
+        </ezcontent>
+        <ezconfig><ezvalue key="title">Bulbo</ezvalue></ezconfig>
+    </eztemplate>
+</section>',
+            ],
+        ];
+    }
+}

--- a/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
@@ -91,15 +91,25 @@ class TemplateTest extends TestCase
                 if (!empty($params['params']['content'])) {
                     // mock simple converter
                     $contentDoc = new DOMDocument();
+
+                    $xml = '<section xmlns="http://docbook.org/ns/docbook">';
+                    $xml .= $params['params']['content'];
+                    $xml .= '</section>';
+
+                    $params['params']['content'] = $xml;
+
                     $fragment = $contentDoc->createDocumentFragment();
-                    $fragment->appendXML($params['params']['content']);
+                    $fragment->appendXML($xml);
+
                     $contentDoc->appendChild($fragment);
+
                     $this->converterMock
                         ->expects($this->at($convertIndex++))
                         ->method('convert')
                         ->with($contentDoc)
                         ->will($this->returnValue($contentDoc));
                 }
+
                 $this->rendererMock
                     ->expects($this->at($index))
                     ->method('renderTemplate')
@@ -239,7 +249,7 @@ class TemplateTest extends TestCase
                 'is_inline' => false,
                 'params' => [
                     'name' => 'custom_tag',
-                    'content' => '<para xmlns="http://docbook.org/ns/docbook">Param: value</para>',
+                    'content' => '<para>Param: value</para>',
                     'params' => [
                         'param' => 'value',
                     ],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30166](https://jira.ez.no/browse/EZP-30166)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 2.4?
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

The cause of the problem seems to be two things:
* In https://github.com/ezsystems/ezplatform-richtext/commit/23bd49b3797319f3ae2350ba1536dfd9a1e6dd31#diff-7310606d4fef503a40dee782da35ae00R210 we create a DOM document with multiple root notes
* DOMXPath seems to only take namespace definitions from the first parent element, and use the same ones on any other root elements. 

So in https://github.com/ezsystems/ezplatform-richtext/blob/master/src/lib/eZ/RichText/Converter/Link.php#L67, if the DOMDocument looks like this:

```
<?xml version="1.0"?>
<para xmlns="http://docbook.org/ns/docbook">Just a regular text</para>
<para xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"><link xlink:href="" xlink:show="none">ezlocation URL</link></para>
<para xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"><link xlink:href="ezurl://1" xlink:show="none" xlink:title="">ezurl URL </link></para>
```

Then the namespace in `<link xlink:href=""(..)` will not be recognized and we'll get the reported behaviour : `An exception has been thrown during the rendering of a template ("Warning: DOMXPath::query(): Undefined namespace prefix") in "@admin/fieldtypes/preview/content_fields.html.twig".`

If you would swap the two firsts two `<para>`, then the warning will not be thrown, for the reasons explained above:

```
<?xml version="1.0"?>
<para xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"><link xlink:href="" xlink:show="none">ezlocation URL</link></para>
<para xmlns="http://docbook.org/ns/docbook">Just a regular text</para>
<para xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"><link xlink:href="ezurl://1" xlink:show="none" xlink:title="">ezurl URL </link></para>
```

My fix is to render each root node one-by-one. AFAIK, that should not change the end result

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix tests tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
