### PR TITLE
EZP-29876: New break lines disappear in Richtext while styled with custom styles

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -657,7 +657,7 @@
     <xsl:apply-templates select="node()|@*"/>
   </xsl:template>
 
-  <xsl:template match="docbook:eztemplate[@type='style']/docbook:ezcontent/text()">
+  <xsl:template match="docbook:eztemplate/docbook:ezcontent/text()">
     <xsl:call-template name="breakLine">
       <xsl:with-param name="text" select="."/>
     </xsl:call-template>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -657,6 +657,12 @@
     <xsl:apply-templates select="node()|@*"/>
   </xsl:template>
 
+  <xsl:template match="docbook:eztemplate[@type='style']/docbook:ezcontent/text()">
+    <xsl:call-template name="breakLine">
+      <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+
   <xsl:template match="docbook:eztemplateinline[@type='style']/docbook:ezcontent">
     <xsl:apply-templates select="node()|@*"/>
   </xsl:template>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -41,6 +41,12 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="docbook:section/text()">
+      <xsl:call-template name="breakLine">
+        <xsl:with-param name="text" select="."/>
+      </xsl:call-template>
+  </xsl:template>
+
   <xsl:template match="docbook:para">
     <xsl:element name="p" namespace="{$outputNamespace}">
       <xsl:if test="@ezxhtml:class">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -642,7 +642,9 @@
         <!-- Nest content of Style tag in ezcontent -->
         <xsl:when test="@data-eztype='style'">
           <xsl:element name="ezcontent" namespace="http://docbook.org/ns/docbook">
-            <xsl:apply-templates/>
+            <xsl:call-template name="breakline">
+              <xsl:with-param name="node" select="node()"/>
+            </xsl:call-template>
           </xsl:element>
         </xsl:when>
         <!-- For other types of tags behave as usual (ezcontent should be defined explicitly) -->

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/031-ezstyle.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/031-ezstyle.xml
@@ -13,4 +13,11 @@
     <eztemplate name="highlighted_block" type="style" ezxhtml:align="center">
         <ezcontent>Highlighted block with "center" align.</ezcontent>
     </eztemplate>
+    <eztemplate name="highlighted_block" type="style">
+        <ezcontent>
+            Highlighted block with multiple lines
+            Highlighted block with multiple lines
+            Highlighted block with multiple lines
+        </ezcontent>
+    </eztemplate>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/031-ezstyle.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/031-ezstyle.xml
@@ -3,4 +3,5 @@
     <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" data-ezalign="left">Highlighted block with "left" align.</div>
     <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" data-ezalign="right">Highlighted block with "right" align.</div>
     <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" data-ezalign="center">Highlighted block with "center" align.</div>
+    <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block"><br/>            Highlighted block with multiple lines<br/>            Highlighted block with multiple lines<br/>            Highlighted block with multiple lines<br/>        </div>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29876](https://jira.ez.no/browse/EZP-29876)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Note for QA: This bugfix depends on https://github.com/ezsystems/ezplatform-richtext/pull/32

**TODO**:
- [X] Implement feature / fix a bug.
- [x] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
