### PR TITLE
EZP-29301: Provided support for custom classes and data attributes

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -440,6 +440,8 @@ class RichText extends AbstractFieldTypeParser
             ->arrayNode(self::ATTRIBUTES_NODE_KEY)
                 ->useAttributeAsKey(self::ELEMENT_NODE_KEY)
                 ->arrayPrototype()
+                    // allow dashes in data attribute name
+                    ->normalizeKeys(false)
                     ->arrayPrototype()
                         ->validate()
                             ->always($this->getAttributesValidatorCallback($invalidChoiceCallback))
@@ -504,6 +506,11 @@ class RichText extends AbstractFieldTypeParser
                         self::CHOICES_NODE_KEY
                     )
                 );
+            }
+
+            // at this point, for non-choice types, unset choice type-related settings
+            if ($v[self::ATTRIBUTE_TYPE_NODE_KEY] !== self::ATTRIBUTE_TYPE_CHOICE) {
+                unset($v[self::CHOICES_NODE_KEY], $v[self::MULTIPLE_NODE_KEY]);
             }
 
             return $v;

--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -18,6 +18,9 @@ use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
  */
 class RichText extends AbstractFieldTypeParser
 {
+    const CLASSES_SA_SETTINGS_ID = 'fieldtypes.ezrichtext.classes';
+    const ATTRIBUTES_SA_SETTINGS_ID = 'fieldtypes.ezrichtext.attributes';
+
     /**
      * Returns the fieldType identifier the config parser works for.
      * This is to create the right configuration node under system.<siteaccess_name>.fieldtypes.
@@ -241,6 +244,17 @@ class RichText extends AbstractFieldTypeParser
                     );
                 }
             }
+
+            $onlineEditorSettingsMap = [
+                'classes' => self::CLASSES_SA_SETTINGS_ID,
+                'attributes' => self::ATTRIBUTES_SA_SETTINGS_ID,
+            ];
+            foreach ($onlineEditorSettingsMap as $key => $settingsId) {
+                if (isset($scopeSettings['fieldtypes']['ezrichtext'][$key])) {
+                    $scopeSettings[$settingsId] = $scopeSettings['fieldtypes']['ezrichtext'][$key];
+                    unset($scopeSettings['fieldtypes']['ezrichtext'][$key]);
+                }
+            }
         }
     }
 
@@ -251,6 +265,8 @@ class RichText extends AbstractFieldTypeParser
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.output_custom_xsl', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.edit_custom_xsl', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.input_custom_xsl', $config);
+        $contextualizer->mapConfigArray(static::CLASSES_SA_SETTINGS_ID, $config);
+        $contextualizer->mapConfigArray(static::ATTRIBUTES_SA_SETTINGS_ID, $config);
     }
 
     /**

--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -463,7 +463,7 @@ class RichText extends AbstractFieldTypeParser
                                 ->scalarPrototype()
                                 ->end()
                             ->end()
-                            ->booleanNode(self::MULTIPLE_NODE_KEY)->defaultTrue()->end()
+                            ->booleanNode(self::MULTIPLE_NODE_KEY)->defaultFalse()->end()
                             ->booleanNode(self::REQUIRED_NODE_KEY)->defaultFalse()->end()
                             ->scalarNode(self::DEFAULT_VALUE_NODE_KEY)->end()
                         ->end()

--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -19,23 +19,23 @@ use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
  */
 class RichText extends AbstractFieldTypeParser
 {
-    const CLASSES_SA_SETTINGS_ID = 'fieldtypes.ezrichtext.classes';
-    const CLASSES_NODE_KEY = 'classes';
+    public const CLASSES_SA_SETTINGS_ID = 'fieldtypes.ezrichtext.classes';
+    private const CLASSES_NODE_KEY = 'classes';
 
-    const ATTRIBUTES_SA_SETTINGS_ID = 'fieldtypes.ezrichtext.attributes';
-    const ATTRIBUTES_NODE_KEY = 'attributes';
-    const ATTRIBUTE_TYPE_NODE_KEY = 'type';
-    const ATTRIBUTE_TYPE_CHOICE = 'choice';
-    const ATTRIBUTE_TYPE_BOOLEAN = 'boolean';
-    const ATTRIBUTE_TYPE_STRING = 'string';
-    const ATTRIBUTE_TYPE_NUMBER = 'number';
+    public const ATTRIBUTES_SA_SETTINGS_ID = 'fieldtypes.ezrichtext.attributes';
+    private const ATTRIBUTES_NODE_KEY = 'attributes';
+    private const ATTRIBUTE_TYPE_NODE_KEY = 'type';
+    private const ATTRIBUTE_TYPE_CHOICE = 'choice';
+    private const ATTRIBUTE_TYPE_BOOLEAN = 'boolean';
+    private const ATTRIBUTE_TYPE_STRING = 'string';
+    private const ATTRIBUTE_TYPE_NUMBER = 'number';
 
     // constants common for OE custom classes and data attributes configuration
-    const ELEMENT_NODE_KEY = 'element';
-    const DEFAULT_VALUE_NODE_KEY = 'default_value';
-    const CHOICES_NODE_KEY = 'choices';
-    const REQUIRED_NODE_KEY = 'required';
-    const MULTIPLE_NODE_KEY = 'multiple';
+    private const ELEMENT_NODE_KEY = 'element';
+    private const DEFAULT_VALUE_NODE_KEY = 'default_value';
+    private const CHOICES_NODE_KEY = 'choices';
+    private const REQUIRED_NODE_KEY = 'required';
+    private const MULTIPLE_NODE_KEY = 'multiple';
 
     /**
      * Returns the fieldType identifier the config parser works for.
@@ -281,10 +281,10 @@ class RichText extends AbstractFieldTypeParser
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.output_custom_xsl', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.edit_custom_xsl', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.input_custom_xsl', $config);
-        $contextualizer->mapConfigArray(static::CLASSES_SA_SETTINGS_ID, $config);
+        $contextualizer->mapConfigArray(self::CLASSES_SA_SETTINGS_ID, $config);
         // merge attributes of the same element from different scopes
         $contextualizer->mapConfigArray(
-            static::ATTRIBUTES_SA_SETTINGS_ID,
+            self::ATTRIBUTES_SA_SETTINGS_ID,
             $config,
             ContextualizerInterface::MERGE_FROM_SECOND_LEVEL
         );

--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -171,6 +171,8 @@ class RichText extends AbstractFieldTypeParser
                 ->info('List of RichText Custom Styles enabled for the current scope. The Custom Styles must be defined in ezpublish.ezrichtext.custom_styles Node.')
                 ->scalarPrototype()->end()
             ->end();
+
+        $this->buildOnlineEditorConfiguration($nodeBuilder);
     }
 
     /**
@@ -352,5 +354,53 @@ class RichText extends AbstractFieldTypeParser
                 ->end()
             ->end()
         ;
+    }
+
+    /**
+     * Build configuration nodes strictly related to Online Editor.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder
+     */
+    private function buildOnlineEditorConfiguration(NodeBuilder $nodeBuilder): void
+    {
+        $nodeBuilder
+            ->arrayNode('classes')
+                ->useAttributeAsKey('element')
+                ->arrayPrototype()
+                    ->children()
+                        ->arrayNode('choices')
+                            ->scalarPrototype()->end()
+                            ->isRequired()
+                        ->end()
+                        ->booleanNode('required')
+                            ->defaultFalse()
+                        ->end()
+                        ->scalarNode('default_value')
+                        ->end()
+                        ->booleanNode('multiple')
+                            ->defaultTrue()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->arrayNode('attributes')
+                ->useAttributeAsKey('element')
+                ->arrayPrototype()
+                    ->arrayPrototype()
+                        ->children()
+                            ->enumNode('type')
+                                ->isRequired()
+                                ->values(['choice', 'boolean', 'string', 'number'])
+                            ->end()
+                            ->arrayNode('choices')
+                                ->scalarPrototype()->end()
+                            ->end()
+                            ->booleanNode('multiple')->defaultTrue()->end()
+                            ->booleanNode('required')->defaultFalse()->end()
+                            ->scalarNode('default_value')->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
     }
 }

--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -282,7 +282,12 @@ class RichText extends AbstractFieldTypeParser
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.edit_custom_xsl', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.input_custom_xsl', $config);
         $contextualizer->mapConfigArray(static::CLASSES_SA_SETTINGS_ID, $config);
-        $contextualizer->mapConfigArray(static::ATTRIBUTES_SA_SETTINGS_ID, $config);
+        // merge attributes of the same element from different scopes
+        $contextualizer->mapConfigArray(
+            static::ATTRIBUTES_SA_SETTINGS_ID,
+            $config,
+            ContextualizerInterface::MERGE_FROM_SECOND_LEVEL
+        );
     }
 
     /**

--- a/src/bundle/DependencyInjection/EzPlatformRichTextExtension.php
+++ b/src/bundle/DependencyInjection/EzPlatformRichTextExtension.php
@@ -71,6 +71,7 @@ class EzPlatformRichTextExtension extends Extension implements PrependExtensionI
         $loader->load('rest.yml');
         $loader->load('templating.yml');
         $loader->load('form.yml');
+        $loader->load('translation.yml');
 
         // load Kernel BC layer
         $loader->load('bc/aliases.yml');

--- a/src/bundle/Resources/config/translation.yml
+++ b/src/bundle/Resources/config/translation.yml
@@ -1,0 +1,11 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    EzSystems\EzPlatformRichText\Translation\Extractor\OnlineEditorCustomAttributesExtractor:
+        arguments:
+            $siteAccessList: '%ezpublish.siteaccess.list%'
+        tags:
+            - { name: jms_translation.extractor, alias: ez_online_editor_attributes }

--- a/src/bundle/Resources/views/RichText/embed/content.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/content.html.twig
@@ -5,8 +5,16 @@
 {% if embedParams.link is defined  %}
     {% set params = params|merge( { "linkParameters": embedParams.link } ) %}
 {% endif %}
+{% if embedParams.dataAttributes is defined %}
+    {# Note: intentionally using here new convention for parameter names #}
+    {% set data_attributes_str = ' ' ~ embedParams.dataAttributes|ez_data_attributes_serialize %}
+    {# Note: passing data attributes as param for 3rd party overridden embed views #}
+    {% set params = params|merge( { "data_attributes": embedParams.dataAttributes } ) %}
+{% else %}
+    {% set data_attributes_str = '' %}
+{% endif %}
 
-<div {% if embedParams.anchor is defined %}id="{{ embedParams.anchor }}"{% endif %} class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
+<div {% if embedParams.anchor is defined %}id="{{ embedParams.anchor }}"{% endif %} class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}"{{ data_attributes_str|raw }}>
     {{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
     {{
         render(

--- a/src/bundle/Resources/views/RichText/embed/content_inline.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/content_inline.html.twig
@@ -5,6 +5,11 @@
 {% if embedParams.link is defined  %}
     {% set params = params|merge( { "linkParameters": embedParams.link } ) %}
 {% endif %}
+{% if embedParams.dataAttributes is defined %}
+    {# Note: intentionally using here new convention for parameter names #}
+    {% set params = params|merge( { "data_attributes": embedParams.dataAttributes } ) %}
+{% endif %}
+
 {{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
 {{
     render(

--- a/src/bundle/Resources/views/RichText/embed/content_inline.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/content_inline.html.twig
@@ -9,6 +9,9 @@
     {# Note: intentionally using here new convention for parameter names #}
     {% set params = params|merge( { "data_attributes": embedParams.dataAttributes } ) %}
 {% endif %}
+{% if embedParams.class is defined %}
+    {% set params = params|merge( { "class": embedParams.class } ) %}
+{% endif %}
 
 {{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
 {{

--- a/src/bundle/Resources/views/RichText/embed/location.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location.html.twig
@@ -9,6 +9,9 @@
     {# Note: intentionally using here new convention for parameter names #}
     {% set params = params|merge( { "data_attributes": embedParams.dataAttributes } ) %}
 {% endif %}
+{% if embedParams.class is defined %}
+    {% set params = params|merge( { "class": embedParams.class } ) %}
+{% endif %}
 
 <div {% if embedParams.anchor is defined %}id="{{ embedParams.anchor }}"{% endif %} class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
     {{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}

--- a/src/bundle/Resources/views/RichText/embed/location.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location.html.twig
@@ -5,6 +5,10 @@
 {% if embedParams.link is defined  %}
     {% set params = params|merge( { "linkParameters": embedParams.link } ) %}
 {% endif %}
+{% if embedParams.dataAttributes is defined %}
+    {# Note: intentionally using here new convention for parameter names #}
+    {% set params = params|merge( { "data_attributes": embedParams.dataAttributes } ) %}
+{% endif %}
 
 <div {% if embedParams.anchor is defined %}id="{{ embedParams.anchor }}"{% endif %} class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
     {{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}

--- a/src/bundle/Resources/views/RichText/embed/location_inline.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location_inline.html.twig
@@ -9,6 +9,9 @@
     {# Note: intentionally using here new convention for parameter names #}
     {% set params = params|merge( { "data_attributes": embedParams.dataAttributes } ) %}
 {% endif %}
+{% if embedParams.class is defined %}
+    {% set params = params|merge( { "class": embedParams.class } ) %}
+{% endif %}
 
 {{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
 {{

--- a/src/bundle/Resources/views/RichText/embed/location_inline.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location_inline.html.twig
@@ -5,6 +5,11 @@
 {% if embedParams.link is defined  %}
     {% set params = params|merge( { "linkParameters": embedParams.link } ) %}
 {% endif %}
+{% if embedParams.dataAttributes is defined %}
+    {# Note: intentionally using here new convention for parameter names #}
+    {% set params = params|merge( { "data_attributes": embedParams.dataAttributes } ) %}
+{% endif %}
+
 {{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
 {{
     render(

--- a/src/lib/Translation/Extractor/OnlineEditorCustomAttributesExtractor.php
+++ b/src/lib/Translation/Extractor/OnlineEditorCustomAttributesExtractor.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformRichText\Translation\Extractor;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\EzPlatformRichTextBundle\DependencyInjection\Configuration\Parser\FieldType\RichText;
+use JMS\TranslationBundle\Model\MessageCatalogue;
+use JMS\TranslationBundle\Model\Message\XliffMessage;
+use JMS\TranslationBundle\Translation\ExtractorInterface;
+
+/**
+ * Generates translation strings for limitation types.
+ */
+final class OnlineEditorCustomAttributesExtractor implements ExtractorInterface
+{
+    private const MESSAGE_DOMAIN = 'online_editor';
+    private const ATTRIBUTES_MESSAGE_ID_PREFIX = 'ezrichtext.attributes';
+    private const CLASS_LABEL_MESSAGE_ID = 'ezrichtext.classes.class.label';
+
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var string[]
+     */
+    private $siteAccessList;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     * @param string[] $siteAccessList
+     */
+    public function __construct(ConfigResolverInterface $configResolver, array $siteAccessList)
+    {
+        $this->configResolver = $configResolver;
+        $this->siteAccessList = $siteAccessList;
+    }
+
+    /**
+     * Iterate over each scope and extract custom attributes label names.
+     *
+     * @return \JMS\TranslationBundle\Model\MessageCatalogue
+     */
+    public function extract(): MessageCatalogue
+    {
+        $catalogue = new MessageCatalogue();
+
+        $catalogue->add($this->createMessage(self::CLASS_LABEL_MESSAGE_ID, 'Class'));
+
+        foreach ($this->siteAccessList as $scope) {
+            if (!$this->configResolver->hasParameter(RichText::ATTRIBUTES_SA_SETTINGS_ID)) {
+                continue;
+            }
+            $this->extractMessagesForScope($catalogue, $scope);
+        }
+
+        return $catalogue;
+    }
+
+    /**
+     * @param string $id
+     * @param string $desc
+     *
+     * @return \JMS\TranslationBundle\Model\Message\XliffMessage
+     */
+    private function createMessage(string $id, string $desc): XliffMessage
+    {
+        $message = new XliffMessage($id, self::MESSAGE_DOMAIN);
+        $message->setNew(false);
+        $message->setMeaning($desc);
+        $message->setDesc($desc);
+        $message->setLocaleString($desc);
+        $message->addNote('key: ' . $id);
+
+        return $message;
+    }
+
+    /**
+     * Extract messages from the given scope into the catalogue.
+     *
+     * @param \JMS\TranslationBundle\Model\MessageCatalogue $catalogue
+     * @param string $scope
+     */
+    private function extractMessagesForScope(MessageCatalogue $catalogue, string $scope): void
+    {
+        $attributes = $this->configResolver->getParameter(
+            RichText::ATTRIBUTES_SA_SETTINGS_ID,
+            null,
+            $scope
+        );
+        foreach ($attributes as $elementName => $attributesConfig) {
+            foreach (array_keys($attributesConfig) as $attributeName) {
+                $messageId = sprintf(
+                    '%s.%s.%s.label',
+                    self::ATTRIBUTES_MESSAGE_ID_PREFIX,
+                    $elementName,
+                    $attributeName
+                );
+                // by default let's use attribute name
+                $catalogue->add(
+                    $this->createMessage($messageId, $attributeName)
+                );
+            }
+        }
+    }
+}

--- a/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -866,6 +866,9 @@
     <define name="db.superscript.attlist" combine="interleave">
       <ref name="ez.xhtml.data.attribute" />
     </define>
+    <define name="ez.embed.content" combine="interleave">
+      <ref name="ez.xhtml.data.attribute" />
+    </define>
   </div>
 
 </grammar>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -321,15 +321,15 @@
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="docbook:orderedlist/docbook:listitem/docbook:para | docbook:itemizedlist/docbook:listitem/docbook:para">
+  <xsl:template match="docbook:orderedlist/docbook:listitem | docbook:itemizedlist/docbook:listitem">
     <xsl:element name="li" namespace="{$outputNamespace}">
-      <xsl:if test="../@ezxhtml:class">
+      <xsl:if test="@ezxhtml:class">
         <xsl:attribute name="class">
-          <xsl:value-of select="../@ezxhtml:class"/>
+          <xsl:value-of select="@ezxhtml:class"/>
         </xsl:attribute>
       </xsl:if>
       <xsl:call-template name="ezattribute"/>
-      <xsl:apply-templates/>
+      <xsl:apply-templates select="./docbook:para/node()" />
     </xsl:element>
   </xsl:template>
 

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -567,6 +567,7 @@
     <xsl:element name="div" namespace="{$outputNamespace}">
       <xsl:attribute name="data-ezelement">ezembed</xsl:attribute>
       <xsl:call-template name="addCommonEmbedAttributes"/>
+      <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
     </xsl:element>
   </xsl:template>
@@ -575,8 +576,9 @@
     <xsl:element name="span" namespace="{$outputNamespace}">
       <xsl:attribute name="data-ezelement">ezembedinline</xsl:attribute>
       <xsl:call-template name="addCommonEmbedAttributes"/>
+      <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
-      <xsl:if test="not(node())">
+      <xsl:if test="./docbook:ezattribute or not(node())">
         <xsl:text> </xsl:text>
       </xsl:if>
     </xsl:element>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -335,15 +335,15 @@
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="docbook:orderedlist/docbook:listitem/docbook:para | docbook:itemizedlist/docbook:listitem/docbook:para">
+  <xsl:template match="docbook:orderedlist/docbook:listitem | docbook:itemizedlist/docbook:listitem">
     <xsl:element name="li" namespace="{$outputNamespace}">
-      <xsl:if test="../@ezxhtml:class">
+      <xsl:if test="@ezxhtml:class">
         <xsl:attribute name="class">
-          <xsl:value-of select="../@ezxhtml:class"/>
+          <xsl:value-of select="@ezxhtml:class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:call-template name="ezattribute" select="parent"/>
-      <xsl:apply-templates/>
+      <xsl:call-template name="ezattribute" />
+      <xsl:apply-templates select="./docbook:para/node()" />
     </xsl:element>
   </xsl:template>
 

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -584,6 +584,7 @@
   <xsl:template match="ezxhtml5:div[@data-ezelement='ezembed']">
     <xsl:element name="ezembed" namespace="http://docbook.org/ns/docbook">
       <xsl:call-template name="addCommonEmbedAttributes"/>
+      <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates select="node()[not(self::text())]"/>
     </xsl:element>
   </xsl:template>
@@ -591,6 +592,7 @@
   <xsl:template match="ezxhtml5:span[@data-ezelement='ezembedinline']">
     <xsl:element name="ezembedinline" namespace="http://docbook.org/ns/docbook">
       <xsl:call-template name="addCommonEmbedAttributes"/>
+      <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates select="node()[not(self::text())]"/>
     </xsl:element>
   </xsl:template>

--- a/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -503,6 +503,48 @@ class RichTextTest extends AbstractParserTestCase
                     ],
                 ],
             ],
+            [
+                [
+                    'fieldtypes' => [
+                        'ezrichtext' => [
+                            'attributes' => [
+                                'paragraph' => [
+                                    'select-single-attr' => [
+                                        'choices' => ['class1', 'class2'],
+                                        'type' => 'choice',
+                                        'required' => true,
+                                        'default_value' => 'class1',
+                                    ],
+                                ],
+                                'headline' => [
+                                    'text-attr' => [
+                                        'type' => 'string',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'fieldtypes.ezrichtext.attributes' => [
+                        'paragraph' => [
+                            'select-single-attr' => [
+                                'choices' => ['class1', 'class2'],
+                                'type' => 'choice',
+                                'required' => true,
+                                'default_value' => 'class1',
+                                'multiple' => false,
+                            ],
+                        ],
+                        'headline' => [
+                            'text-attr' => [
+                                'type' => 'string',
+                                'required' => false,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 }

--- a/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -153,6 +153,102 @@ class RichTextTest extends AbstractParserTestCase
     }
 
     /**
+     * Test expected semantic config validation for online editor settings.
+     *
+     * @dataProvider getOnlineEditorInvalidSettings
+     *
+     * @param array $config
+     * @param string $expectedExceptionMessage
+     *
+     * @throws \Exception
+     */
+    public function testOnlineEditorInvalidSettingsThrowException(
+        array $config,
+        string $expectedExceptionMessage
+    ): void {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        $this->load(
+            [
+                'ezpublish' => [
+                    'system' => [
+                        'ezdemo_site' => [
+                            'fieldtypes' => [
+                                'ezrichtext' => $config,
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Data provider for testOnlineEditorInvalidSettings.
+     *
+     * @see testOnlineEditorInvalidSettingsThrowException
+     *
+     * @return array
+     */
+    public function getOnlineEditorInvalidSettings(): array
+    {
+        return [
+            [
+                [
+                    'classes' => [
+                        'paragraph' => [
+                            'choices' => ['class1', 'class2'],
+                            'default_value' => 'class3',
+                        ],
+                    ],
+                ],
+                'Default value must be one of the possible choices',
+            ],
+            [
+                [
+                    'attributes' => [
+                        'paragraph' => [
+                            'select-single-attr' => [
+                                'type' => 'choice',
+                                'choices' => ['class1', 'class2'],
+                                'default_value' => 'class3',
+                            ],
+                        ],
+                    ],
+                ],
+                'Default value must be one of the possible choices',
+            ],
+            [
+                [
+                    'attributes' => [
+                        'paragraph' => [
+                            'boolean-attr' => [
+                                'type' => 'boolean',
+                                'required' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                'Boolean type does not support "required" setting',
+            ],
+            [
+                [
+                    'attributes' => [
+                        'paragraph' => [
+                            'boolean-attr' => [
+                                'type' => 'number',
+                                'choices' => ['foo'],
+                            ],
+                        ],
+                    ],
+                ],
+                'Number type does not support "choices" setting',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider richTextSettingsProvider
      *
      * @param array $config
@@ -369,6 +465,40 @@ class RichTextTest extends AbstractParserTestCase
                                     'index' => true,
                                 ],
                             ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'fieldtypes' => [
+                        'ezrichtext' => [
+                            'classes' => [
+                                'paragraph' => [
+                                    'choices' => ['class1', 'class2'],
+                                    'required' => true,
+                                    'default_value' => 'class1',
+                                    'multiple' => true,
+                                ],
+                                'headline' => [
+                                    'choices' => ['class3', 'class4'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'fieldtypes.ezrichtext.classes' => [
+                        'paragraph' => [
+                            'choices' => ['class1', 'class2'],
+                            'required' => true,
+                            'default_value' => 'class1',
+                            'multiple' => true,
+                        ],
+                        'headline' => [
+                            'choices' => ['class3', 'class4'],
+                            'required' => false,
+                            'multiple' => true,
                         ],
                     ],
                 ],

--- a/tests/lib/eZ/RichText/Converter/Render/EmbedTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/EmbedTest.php
@@ -23,7 +23,17 @@ class EmbedTest extends TestCase
         parent::setUp();
     }
 
-    public function providerForTestConvert()
+    /**
+     * Data provider for testConvert.
+     *
+     * @see testConvert
+     *
+     * Provided parameters:
+     * <code>string $xmlString, string $expectedXmlString, array $errors, array $renderParams</code>
+     *
+     * @return array
+     */
+    public function providerForTestConvert(): array
     {
         return [
             [
@@ -461,14 +471,109 @@ class EmbedTest extends TestCase
                     ],
                 ],
             ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <para>
+    <ezattribute>
+      <ezvalue key="not-related-attr">not related value</ezvalue>
+    </ezattribute>
+    <ezembedinline xlink:href="ezcontent://106" view="embed-inline">
+      <ezattribute>
+        <ezvalue key="inline-choice-attr">choice1</ezvalue>
+        <ezvalue key="inline-choice-mul-attr">choice2,choice3</ezvalue>
+      </ezattribute>
+    </ezembedinline>
+  </para>
+</section>',
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <para>
+    <ezattribute>
+      <ezvalue key="not-related-attr">not related value</ezvalue>
+    </ezattribute>
+    <ezembedinline xlink:href="ezcontent://106" view="embed-inline">
+      <ezattribute>
+        <ezvalue key="inline-choice-attr">choice1</ezvalue>
+        <ezvalue key="inline-choice-mul-attr">choice2,choice3</ezvalue>
+      </ezattribute>
+      <ezpayload>106</ezpayload>
+    </ezembedinline>
+  </para>
+</section>',
+                [],
+                [
+                    [
+                        'method' => 'renderContentEmbed',
+                        'id' => '106',
+                        'viewType' => 'embed-inline',
+                        'is_inline' => true,
+                        'embedParams' => [
+                            'id' => '106',
+                            'viewType' => 'embed-inline',
+                            'dataAttributes' => [
+                                'inline-choice-attr' => 'choice1',
+                                'inline-choice-mul-attr' => 'choice2,choice3',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <ezembed xlink:href="ezcontent://106">
+    <ezattribute>
+       <ezvalue key="inline-choice-attr">choice1</ezvalue>
+       <ezvalue key="inline-choice-mul-attr">choice2,choice3</ezvalue>
+    </ezattribute>
+  </ezembed>
+</section>',
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <ezembed xlink:href="ezcontent://106">
+    <ezattribute>
+      <ezvalue key="inline-choice-attr">choice1</ezvalue>
+      <ezvalue key="inline-choice-mul-attr">choice2,choice3</ezvalue>
+    </ezattribute>
+    <ezpayload><![CDATA[106]]></ezpayload>
+  </ezembed>
+</section>',
+                [],
+                [
+                    [
+                        'method' => 'renderContentEmbed',
+                        'id' => '106',
+                        'viewType' => 'embed',
+                        'is_inline' => false,
+                        'embedParams' => [
+                            'id' => '106',
+                            'viewType' => 'embed',
+                            'dataAttributes' => [
+                                'inline-choice-attr' => 'choice1',
+                                'inline-choice-mul-attr' => 'choice2,choice3',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 
     /**
      * @dataProvider providerForTestConvert
+     *
+     * @param string $xmlString
+     * @param string $expectedXmlString
+     * @param array $errors
+     * @param array $renderParams
      */
-    public function testConvert($xmlString, $expectedXmlString, array $errors, array $renderParams)
-    {
+    public function testConvert(
+        string $xmlString,
+        string $expectedXmlString,
+        array $errors,
+        array $renderParams
+    ) {
         if (isset($errors)) {
             foreach ($errors as $index => $error) {
                 $this->loggerMock

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/008-orderedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/008-orderedList.xml
@@ -9,6 +9,11 @@
       <ezvalue key="name-1">value 1</ezvalue>
       <ezvalue key="name-2">value 2</ezvalue>
     </ezattribute>
-    <listitem ezxhtml:class="listItemClass"><para>This is a list item.</para></listitem>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-2">value 2</ezvalue>
+      </ezattribute>
+      <para>This is a list item.</para>
+    </listitem>
   </orderedlist>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/022-embed.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/022-embed.xml
@@ -12,4 +12,10 @@
     </ezconfig>
   </ezembed>
   <ezembed xlink:href="ezlocation://601" view="line" xml:id="embed-id-2" ezxhtml:class="embedClass2" ezxhtml:align="right"/>
+  <ezembed xlink:href="ezlocation://601" view="embed" xml:id="embed-id-3" ezxhtml:align="right">
+    <ezattribute>
+      <ezvalue key="name-1">value 1</ezvalue>
+      <ezvalue key="name-2">value 2</ezvalue>
+    </ezattribute>
+  </ezembed>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/023-embedInline.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/023-embedInline.xml
@@ -10,4 +10,5 @@
       <ezvalue key="size">medium</ezvalue>
     </ezconfig>
   </ezembedinline> content.</para>
+  <para>Some<ezembedinline xlink:href="ezcontent://601" xml:id="id4"><ezattribute><ezvalue key="name-1">value 1</ezvalue><ezvalue key="name-2">value 2</ezvalue></ezattribute></ezembedinline> content.</para>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/035-itemizedListWithNestedElements.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/035-itemizedListWithNestedElements.xml
@@ -5,15 +5,8 @@
          xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
          version="5.0-variant ezpublish-1.0">
   <itemizedlist>
-    <ezattribute>
-      <ezvalue key="name-1">value 1</ezvalue>
-      <ezvalue key="name-2">value 2</ezvalue>
-    </ezattribute>
-    <listitem ezxhtml:class="listItemClass">
-      <ezattribute>
-        <ezvalue key="name-2">value 2</ezvalue>
-      </ezattribute>
-      <para>This is a list item.</para>
+    <listitem>
+      <para>This is a list item <ezembedinline xlink:href="ezcontent://52" view="embed-inline"/></para>
     </listitem>
   </itemizedlist>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/008-orderedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/008-orderedList.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
   <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" id="orderedlist-id">
-    <li class="listItemClass">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
   </ol>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/009-itemizedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/009-itemizedList.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
   <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2">
-    <li class="listItemClass">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
   </ul>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/022-embed.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/022-embed.xml
@@ -8,4 +8,5 @@
     </span>
   </div>
   <div data-ezelement="ezembed" data-href="ezlocation://601" id="embed-id-2" data-ezview="line" class="embedClass2" data-ezalign="right"/>
+  <div data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembed" data-href="ezlocation://601" id="embed-id-3" data-ezview="embed" data-ezalign="right"/>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/023-embedInline.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/023-embedInline.xml
@@ -6,4 +6,5 @@
       <span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>
     </span>
   </span> content.</p>
+  <p>Some<span data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembedinline" id="id4" data-href="ezcontent://601"> </span> content.</p>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/035-itemizedListWithNestedElements.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/035-itemizedListWithNestedElements.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+  <ul>
+    <li>This is a list item <span data-ezelement="ezembedinline" data-href="ezcontent://52" data-ezview="embed-inline"> </span></li>
+  </ul>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/008-orderedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/008-orderedList.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" id="orderedlist-id">
-    <li class="listItemClass">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
   </ol>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/009-itemizedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/009-itemizedList.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2">
-    <li class="listItemClass">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
   </ul>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/023-embedInline.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/023-embedInline.xml
@@ -2,4 +2,5 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <p>Some  for the otherwise unremarkable paragraph.</p>
   <p>This paragraph is just showing off its  content.</p>
+  <p>Some content.</p>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/035-itemizedListWithNestedElements.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/035-itemizedListWithNestedElements.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
+  <ul>
+    <li>This is a list item </li>
+  </ul>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29301](https://jira.ez.no/browse/EZP-29301)
| **Required by** | ezsystems/ezplatform-admin-ui#996
| **Requires** | ezsystems/ezpublish-kernel#2665
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `1.1.2` for eZ Platform `2.5.2`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR provides SiteAccess-aware semantic configuration for custom classes and attributes of RichText elements. AlloyEditor integration is provided via ezsystems/ezplatform-admin-ui#996

## Example
A sample configuration is as follows:
```yaml
ezpublish:
    system:
        <scope>: # e.g. default or admin_group
            fieldtypes:
                ezrichtext:
                    classes:
                        paragraph:
                            choices: ['class1', 'class2']
                            required: true
                            default_value: 'class1'
                            multiple: true
                        heading:
                            choices: ['class3', 'class4']
                            required: false
                            default_value: ''
                            multiple: false
                    attributes:
                        paragraph:
                            'select-single-attr':
                                type: 'choice'
                                multiple: false
                                required: true
                                choices: ['value1', 'value2']
                                default_value: 'value2'
                            'boolean-attr':
                                type: 'boolean'
                                default_value: true
                        heading:
                            'text-attr':
                                type: 'string'
                                default_value: 'foo'
                                required: false
                            'number-attr':
                                type: 'number'
                                default_value: 1
                                required: true
```
This configuration is used by ezplatform-admin-ui to add a possibility to pick a class for an element or or set a data attribute to an element. As a result, output HTML would have `class` and `data-<attribute_name>` properties respectively. For more details please see ezsystems/ezplatform-admin-ui#996.

_Please note that setting this configuration for a site (non-admin) scope has no effect_

The list of elements includes:
- embedinline
- embed
- formatted
- heading
- embedimage
- ul
- ol
- li
- paragraph
- table
- tr
- td

## Validation
1. Each custom CSS class config must define `choices` list.
2. A `default_value` of custom class must be the one from `choices` list.
3. Custom data attributes settings must define for each attribute a `type` as one of the `choice`,  `boolean`, `string`, `number`.
4. If a custom data attribute is not of `choice` type, it must not define `choices` list.
5. A `default_value` of custom data attribute must be the one from `choices` list.
6. A custom data attribute of `boolean` type must not define `required` setting.

## Extracting translations

There's a custom JMS translations compatible translation extractor `ez_online_editor_attributes` which iterates over all scopes to get full list of custom attributes for all elements. It's a first step, but generated translations will require manual editing as by default attribute name is used (which is not very verbose).

Example (`dir` and `output-dir` are arbitrary and project-dependent):
```
php ./bin/console translation:extract --enable-extractor=ez_online_editor_attributes --dir=./app/Resources/views --output-dir=./app/Resources/translations/ --output-format=yaml
```

## Known issues

There is no way to set different translation per scope for the same attribute of the same element. It's element-attribute pair based.

## Naming

We can see that there are two distinct naming conventions. We already have `alloy_editor` nodes. While this configuration does not use the name directly, you can spot `OnlineEditor` in method names here. This is done on purpose. What `alloy_editor` defines is AlloyEditor-specific. However custom classes and attributes (and tags/styles for that matter) are related to Online editor features, which are independent of the editor implementation.

**TODO**:
- [x] Build basic configuration.
- [x] Implement validation of the configuration.
- [x] Implement processing of the configuration.
- [x] Define and implement scope merging rules.
- [x] Implement tests.
- [x] Expose configuration to AdminUI in ezsystems/ezplatform-admin-ui#996
- [x] Implement custom translation extractor for JMS.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
