### PR TITLE
[CS] Locked php-cs-fixer at v2.15.x and aligned codebase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "matthiasnoback/symfony-dependency-injection-test": "~3.0",
-        "friendsofphp/php-cs-fixer": "^2.13"
+        "friendsofphp/php-cs-fixer": "~2.15.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/bundle/eZ/RichText/RendererTest.php
+++ b/tests/bundle/eZ/RichText/RendererTest.php
@@ -48,19 +48,19 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('render')
             ->with($templateName, $parameters)
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $renderer
             ->expects($this->once())
             ->method('getTagTemplateName')
             ->with($name, $isInline)
-            ->will($this->returnValue($templateName));
+            ->willReturn($templateName);
 
         $this->templateEngineMock
             ->expects($this->once())
             ->method('exists')
             ->with($templateName)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->loggerMock
             ->expects($this->never())
@@ -87,7 +87,7 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('getTagTemplateName')
             ->with($name, $isInline)
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->templateEngineMock
             ->expects($this->never())
@@ -119,13 +119,13 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('getTagTemplateName')
             ->with($name, $isInline)
-            ->will($this->returnValue('templateName'));
+            ->willReturn('templateName');
 
         $this->templateEngineMock
             ->expects($this->once())
             ->method('exists')
             ->with($templateName)
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->loggerMock
             ->expects($this->once())
@@ -253,7 +253,7 @@ class RendererTest extends TestCase
                 ->expects($this->once())
                 ->method('render')
                 ->with($renderTemplate, $parameters)
-                ->will($this->returnValue($renderResult));
+                ->willReturn($renderResult);
         }
 
         if (!isset($templateEngineTemplate)) {
@@ -265,7 +265,7 @@ class RendererTest extends TestCase
                 ->expects($this->once())
                 ->method('exists')
                 ->with($templateEngineTemplate)
-                ->will($this->returnValue(true));
+                ->willReturn(true);
         }
 
         if (empty($configResolverParams)) {
@@ -282,7 +282,7 @@ class RendererTest extends TestCase
                     ->expects($this->at($i))
                     ->method($method)
                     ->with($namespace)
-                    ->will($this->returnValue($returnValue));
+                    ->willReturn($returnValue);
                 ++$i;
             }
         }
@@ -339,19 +339,19 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('render')
             ->with($templateName, $parameters)
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $renderer
             ->expects($this->once())
             ->method('getEmbedTemplateName')
             ->with(Renderer::RESOURCE_TYPE_CONTENT, $isInline, $isDenied)
-            ->will($this->returnValue($templateName));
+            ->willReturn($templateName);
 
         $this->templateEngineMock
             ->expects($this->once())
             ->method('exists')
             ->with($templateName)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->loggerMock
             ->expects($this->never())
@@ -395,7 +395,7 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('getEmbedTemplateName')
             ->with(Renderer::RESOURCE_TYPE_CONTENT, $isInline, $isDenied)
-            ->will($this->returnValue($templateName));
+            ->willReturn($templateName);
 
         $this->templateEngineMock
             ->expects($this->never())
@@ -442,13 +442,13 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('getEmbedTemplateName')
             ->with(Renderer::RESOURCE_TYPE_CONTENT, $isInline, $isDenied)
-            ->will($this->returnValue($templateName));
+            ->willReturn($templateName);
 
         $this->templateEngineMock
             ->expects($this->once())
             ->method('exists')
             ->with($templateName)
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->loggerMock
             ->expects($this->once())
@@ -489,19 +489,19 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('render')
             ->with($templateName, $parameters)
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $renderer
             ->expects($this->once())
             ->method('getEmbedTemplateName')
             ->with(Renderer::RESOURCE_TYPE_CONTENT, $isInline, $isDenied)
-            ->will($this->returnValue($templateName));
+            ->willReturn($templateName);
 
         $this->templateEngineMock
             ->expects($this->once())
             ->method('exists')
             ->with($templateName)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->loggerMock
             ->expects($this->once())
@@ -802,7 +802,7 @@ class RendererTest extends TestCase
                 ->expects($this->once())
                 ->method('render')
                 ->with($renderTemplate, $parameters)
-                ->will($this->returnValue($renderResult));
+                ->willReturn($renderResult);
         }
 
         if (!isset($templateEngineTemplate)) {
@@ -814,7 +814,7 @@ class RendererTest extends TestCase
                 ->expects($this->once())
                 ->method('exists')
                 ->with($templateEngineTemplate)
-                ->will($this->returnValue(true));
+                ->willReturn(true);
         }
 
         if (empty($configResolverParams)) {
@@ -831,7 +831,7 @@ class RendererTest extends TestCase
                     ->expects($this->at($i))
                     ->method($method)
                     ->with($namespace)
-                    ->will($this->returnValue($returnValue));
+                    ->willReturn($returnValue);
                 ++$i;
             }
         }
@@ -875,31 +875,31 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('__get')
             ->with('invisible')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $renderer
             ->expects($this->once())
             ->method('checkLocation')
             ->with($locationId)
-            ->will($this->returnValue($mockLocation));
+            ->willReturn($mockLocation);
 
         $renderer
             ->expects($this->once())
             ->method('render')
             ->with($templateName, $parameters)
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $renderer
             ->expects($this->once())
             ->method('getEmbedTemplateName')
             ->with(Renderer::RESOURCE_TYPE_LOCATION, $isInline, $isDenied)
-            ->will($this->returnValue($templateName));
+            ->willReturn($templateName);
 
         $this->templateEngineMock
             ->expects($this->once())
             ->method('exists')
             ->with($templateName)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->loggerMock
             ->expects($this->never())
@@ -926,13 +926,13 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('__get')
             ->with('invisible')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $renderer
             ->expects($this->once())
             ->method('checkLocation')
             ->with($locationId)
-            ->will($this->returnValue($mockLocation));
+            ->willReturn($mockLocation);
 
         $renderer
             ->expects($this->never())
@@ -942,7 +942,7 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('getEmbedTemplateName')
             ->with(Renderer::RESOURCE_TYPE_LOCATION, $isInline, $isDenied)
-            ->will($this->returnValue($templateName));
+            ->willReturn($templateName);
 
         $this->templateEngineMock
             ->expects($this->never())
@@ -973,13 +973,13 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('__get')
             ->with('invisible')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $renderer
             ->expects($this->once())
             ->method('checkLocation')
             ->with($locationId)
-            ->will($this->returnValue($mockLocation));
+            ->willReturn($mockLocation);
 
         $renderer
             ->expects($this->never())
@@ -989,13 +989,13 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('getEmbedTemplateName')
             ->with(Renderer::RESOURCE_TYPE_LOCATION, $isInline, $isDenied)
-            ->will($this->returnValue($templateName));
+            ->willReturn($templateName);
 
         $this->templateEngineMock
             ->expects($this->once())
             ->method('exists')
             ->with($templateName)
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $this->loggerMock
             ->expects($this->once())
@@ -1028,19 +1028,19 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('render')
             ->with($templateName, $parameters)
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $renderer
             ->expects($this->once())
             ->method('getEmbedTemplateName')
             ->with(Renderer::RESOURCE_TYPE_LOCATION, $isInline, $isDenied)
-            ->will($this->returnValue($templateName));
+            ->willReturn($templateName);
 
         $this->templateEngineMock
             ->expects($this->once())
             ->method('exists')
             ->with($templateName)
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->loggerMock
             ->expects($this->once())
@@ -1066,13 +1066,13 @@ class RendererTest extends TestCase
             ->expects($this->once())
             ->method('__get')
             ->with('invisible')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $renderer
             ->expects($this->once())
             ->method('checkLocation')
             ->with($locationId)
-            ->will($this->returnValue($mockLocation));
+            ->willReturn($mockLocation);
 
         $renderer
             ->expects($this->never())
@@ -1312,13 +1312,13 @@ class RendererTest extends TestCase
                 ->expects($this->once())
                 ->method('__get')
                 ->with('invisible')
-                ->will($this->returnValue(false));
+                ->willReturn(false);
 
             $renderer
                 ->expects($this->once())
                 ->method('checkLocation')
                 ->with($locationId)
-                ->will($this->returnValue($mockLocation));
+                ->willReturn($mockLocation);
         }
 
         if (!isset($renderTemplate)) {
@@ -1330,7 +1330,7 @@ class RendererTest extends TestCase
                 ->expects($this->once())
                 ->method('render')
                 ->with($renderTemplate, $parameters)
-                ->will($this->returnValue($renderResult));
+                ->willReturn($renderResult);
         }
 
         if (!isset($templateEngineTemplate)) {
@@ -1342,7 +1342,7 @@ class RendererTest extends TestCase
                 ->expects($this->once())
                 ->method('exists')
                 ->with($templateEngineTemplate)
-                ->will($this->returnValue(true));
+                ->willReturn(true);
         }
 
         if (empty($configResolverParams)) {
@@ -1359,7 +1359,7 @@ class RendererTest extends TestCase
                     ->expects($this->at($i))
                     ->method($method)
                     ->with($namespace)
-                    ->will($this->returnValue($returnValue));
+                    ->willReturn($returnValue);
                 ++$i;
             }
         }

--- a/tests/lib/eZ/FieldType/RichText/RichTextStorageTest.php
+++ b/tests/lib/eZ/FieldType/RichText/RichTextStorageTest.php
@@ -70,7 +70,7 @@ class RichTextStorageTest extends TestCase
             ->expects($this->once())
             ->method('getIdUrlMap')
             ->with($this->equalTo($linkIds))
-            ->will($this->returnValue($linkUrls));
+            ->willReturn($linkUrls);
         $gateway->expects($this->never())->method('getUrlIdMap');
         $gateway->expects($this->never())->method('getContentIds');
         $gateway->expects($this->never())->method('insertUrl');
@@ -200,12 +200,12 @@ class RichTextStorageTest extends TestCase
             ->expects($this->at($gatewayCallIndex++))
             ->method('getUrlIdMap')
             ->with($this->equalTo($linkUrls))
-            ->will($this->returnValue($linkIds));
+            ->willReturn($linkIds);
         $gateway
             ->expects($this->at($gatewayCallIndex++))
             ->method('getContentIds')
             ->with($this->equalTo($remoteIds))
-            ->will($this->returnValue($contentIds));
+            ->willReturn($contentIds);
         $gateway->expects($this->never())->method('getIdUrlMap');
         if (empty($insertLinks)) {
             $gateway->expects($this->never())->method('insertUrl');
@@ -218,7 +218,7 @@ class RichTextStorageTest extends TestCase
                     ->expects($this->at($gatewayCallIndex++))
                     ->method('insertUrl')
                     ->with($this->equalTo($url))
-                    ->will($this->returnValue($id));
+                    ->willReturn($id);
             } else {
                 $id = $linkIds[$url];
             }
@@ -283,12 +283,12 @@ class RichTextStorageTest extends TestCase
             ->expects($this->once())
             ->method('getUrlIdMap')
             ->with($this->equalTo($linkUrls))
-            ->will($this->returnValue($linkIds));
+            ->willReturn($linkIds);
         $gateway
             ->expects($this->once())
             ->method('getContentIds')
             ->with($this->equalTo($remoteIds))
-            ->will($this->returnValue($contentIds));
+            ->willReturn($contentIds);
         $gateway->expects($this->never())->method('getIdUrlMap');
         if (empty($insertLinks)) {
             $gateway->expects($this->never())->method('insertUrl');
@@ -299,7 +299,7 @@ class RichTextStorageTest extends TestCase
                 ->expects($this->at($index + 2))
                 ->method('insertUrl')
                 ->with($this->equalTo($linkMap['url']))
-                ->will($this->returnValue($linkMap['id']));
+                ->willReturn($linkMap['id']);
         }
 
         $versionInfo = new VersionInfo();

--- a/tests/lib/eZ/REST/FieldTypeProcessor/RichTextProcessorTest.php
+++ b/tests/lib/eZ/REST/FieldTypeProcessor/RichTextProcessorTest.php
@@ -45,7 +45,7 @@ EOT;
             ->expects($this->once())
             ->method('convert')
             ->with($this->isInstanceOf('DOMDocument'))
-            ->will($this->returnValue($convertedDocument));
+            ->willReturn($convertedDocument);
 
         $this->assertEquals(
             $processedOutputValue,

--- a/tests/lib/eZ/RichText/Converter/LinkTest.php
+++ b/tests/lib/eZ/RichText/Converter/LinkTest.php
@@ -222,12 +222,12 @@ class LinkTest extends TestCase
         $locationService->expects($this->once())
             ->method('loadLocation')
             ->with($this->equalTo($locationId))
-            ->will($this->returnValue($location));
+            ->willReturn($location);
 
         $urlAliasRouter->expects($this->once())
             ->method('generate')
             ->with($this->equalTo($location))
-            ->will($this->returnValue($urlResolved));
+            ->willReturn($urlResolved);
 
         $converter = new Link($locationService, $contentService, $urlAliasRouter);
 
@@ -427,22 +427,22 @@ class LinkTest extends TestCase
         $contentInfo->expects($this->once())
             ->method('__get')
             ->with($this->equalTo('mainLocationId'))
-            ->will($this->returnValue($locationId));
+            ->willReturn($locationId);
 
         $contentService->expects($this->any())
             ->method('loadContentInfo')
             ->with($this->equalTo($contentId))
-            ->will($this->returnValue($contentInfo));
+            ->willReturn($contentInfo);
 
         $locationService->expects($this->once())
             ->method('loadLocation')
             ->with($this->equalTo($locationId))
-            ->will($this->returnValue($location));
+            ->willReturn($location);
 
         $urlAliasRouter->expects($this->once())
             ->method('generate')
             ->with($this->equalTo($location))
-            ->will($this->returnValue($urlResolved));
+            ->willReturn($urlResolved);
 
         $converter = new Link($locationService, $contentService, $urlAliasRouter);
 

--- a/tests/lib/eZ/RichText/Converter/Render/EmbedTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/EmbedTest.php
@@ -494,7 +494,7 @@ class EmbedTest extends TestCase
                         ],
                         $params['is_inline']
                     )
-                    ->will($this->returnValue($params['id']));
+                    ->willReturn($params['id']);
             }
         } else {
             $this->rendererMock->expects($this->never())->method('renderContentEmbed');

--- a/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
@@ -107,7 +107,7 @@ class TemplateTest extends TestCase
                         ->expects($this->at($convertIndex++))
                         ->method('convert')
                         ->with($contentDoc)
-                        ->will($this->returnValue($contentDoc));
+                        ->willReturn($contentDoc);
                 }
 
                 $this->rendererMock
@@ -119,7 +119,7 @@ class TemplateTest extends TestCase
                         $params['params'],
                         $params['is_inline']
                     )
-                    ->will($this->returnValue($params['name']));
+                    ->willReturn($params['name']);
             }
         } else {
             $this->rendererMock->expects($this->never())->method('renderTemplate');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **Target version** | `1.0`, `1.1`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

It seems that php-cs-fixer does not follow semver at all, so let's lock it at `2.15.x` to avoid fixing config or codebase on its every minor release.

At the same time I've decided that the new rule `php_unit_mock_short_will_return` is useful, so applied it along.

**TODO**:
- [x] Lock php-cs-fixer at `v2.15.x`
- [x] Apply CS rule `php_unit_mock_short_will_return`
- [x] Ask for Code Review.
