### PR TITLE
EZP-30626: Change FieldType::getName() arguments

### DIFF
--- a/src/lib/eZ/FieldType/RichText/Type.php
+++ b/src/lib/eZ/FieldType/RichText/Type.php
@@ -53,11 +53,13 @@ class Type extends FieldType
      * It will be used to generate content name and url alias if current field is designated
      * to be used in the content name/urlAlias pattern.
      *
-     * @param \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value $value
+     * @param \eZ\Publish\SPI\FieldType\Value $value
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+     * @param string $languageCode
      *
      * @return string
      */
-    public function getName(SPIValue $value)
+    public function getName(SPIValue $value, FieldDefinition $fieldDefinition, string $languageCode): string
     {
         $result = null;
         if ($section = $value->xml->documentElement->firstChild) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30626](https://jira.ez.no/browse/EZP-30626)
| **Improvement**| no
| **New feature**    | yes
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |no

This PR adjust FieldType::getName() arguments to be compatible with `eZ\Publish\Core\FieldType\FieldType`

Related to: [https://github.com/ezsystems/ezpublish-kernel/pull/2661](https://github.com/ezsystems/ezpublish-kernel/pull/2661)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
