### PR TITLE
EZP-30631: Fixed retrieving configuration (ezconfig) from DocBook tag

### DIFF
--- a/src/lib/eZ/RichText/Converter/Render.php
+++ b/src/lib/eZ/RichText/Converter/Render.php
@@ -10,6 +10,7 @@ namespace EzSystems\EzPlatformRichText\eZ\RichText\Converter;
 
 use DOMElement;
 use DOMNode;
+use DOMXPath;
 use EzSystems\EzPlatformRichText\eZ\RichText\RendererInterface;
 
 /**
@@ -37,7 +38,10 @@ abstract class Render
     protected function extractConfiguration(DOMElement $embed)
     {
         $hash = [];
-        $configElements = $embed->getElementsByTagName('ezconfig');
+
+        $xpath = new DOMXPath($embed->ownerDocument);
+        $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
+        $configElements = $xpath->query('./docbook:ezconfig', $embed);
 
         if ($configElements->length) {
             $hash = $this->extractHash($configElements->item(0));

--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -99,7 +99,7 @@ class Template extends Render implements Converter
         $templateType = $template->hasAttribute('type') ? $template->getAttribute('type') : 'tag';
         $parameters = [
             'name' => $templateName,
-            'params' => $this->extractTemplateConfiguration($template, $xpath),
+            'params' => $this->extractConfiguration($template),
         ];
 
         $contentNodes = $xpath->query('./docbook:ezcontent', $template);
@@ -206,24 +206,6 @@ class Template extends Render implements Converter
         }
 
         return trim($this->richTextConverter->convert($innerDoc)->saveHTML());
-    }
-
-    /**
-     * Extract configuration hash from a template.
-     *
-     * @param \DOMElement $template
-     * @param \DOMXPath $xpath
-     *
-     * @return array
-     */
-    protected function extractTemplateConfiguration(DOMElement $template, DOMXPath $xpath)
-    {
-        $configElements = $xpath->query('./docbook:ezconfig', $template);
-        if (0 === $configElements->length) {
-            return [];
-        }
-
-        return $this->extractHash($configElements->item(0));
     }
 
     /**

--- a/tests/lib/eZ/RichText/Converter/Render/EmbedTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/EmbedTest.php
@@ -104,7 +104,7 @@ class EmbedTest extends TestCase
             ],
             [
                 '<?xml version="1.0" encoding="UTF-8"?>
-<section xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <ezembed xlink:href="ezlocation://601" view="embed-inline">
     <ezconfig>
       <ezvalue key="size">medium</ezvalue>
@@ -123,7 +123,7 @@ class EmbedTest extends TestCase
   </ezembed>
 </section>',
                 '<?xml version="1.0" encoding="UTF-8"?>
-<section xmlns:xlink="http://www.w3.org/1999/xlink">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <ezembed xlink:href="ezlocation://601" view="embed-inline">
     <ezconfig>
       <ezvalue key="size">medium</ezvalue>
@@ -172,7 +172,7 @@ class EmbedTest extends TestCase
             ],
             [
                 '<?xml version="1.0" encoding="UTF-8"?>
-<section xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
   <ezembed xlink:href="ezlocation://601" view="embed-inline">
     <ezlink href_resolved="RESOLVED" xlink:href="ezcontent://95#fragment1" xlink:show="replace"/>
     <ezconfig>
@@ -192,7 +192,7 @@ class EmbedTest extends TestCase
   </ezembed>
 </section>',
                 '<?xml version="1.0" encoding="UTF-8"?>
-<section xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
   <ezembed xlink:href="ezlocation://601" view="embed-inline">
     <ezlink href_resolved="RESOLVED" xlink:href="ezcontent://95#fragment1" xlink:show="replace"/>
     <ezconfig>
@@ -289,7 +289,7 @@ class EmbedTest extends TestCase
             ],
             [
                 '<?xml version="1.0" encoding="UTF-8"?>
-<section xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
   <ezembedinline xlink:href="ezlocation://601" view="embed">
     <ezlink href_resolved="RESOLVED" xlink:href="ezcontent://95"/>
     <ezconfig>
@@ -304,7 +304,7 @@ class EmbedTest extends TestCase
   </ezembedinline> inline</link> embed</paragraph>
 </section>',
                 '<?xml version="1.0" encoding="UTF-8"?>
-<section xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
   <ezembedinline xlink:href="ezlocation://601" view="embed">
     <ezlink href_resolved="RESOLVED" xlink:href="ezcontent://95"/>
     <ezconfig>
@@ -552,6 +552,61 @@ class EmbedTest extends TestCase
                             'dataAttributes' => [
                                 'inline-choice-attr' => 'choice1',
                                 'inline-choice-mul-attr' => 'choice2,choice3',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+  <paragraph>Here is paragraph with child embed
+    <ezembed xlink:href="ezlocation://601">
+      <ezembed xlink:href="ezlocation://602">
+        <ezconfig>
+          <ezvalue key="nested">value2</ezvalue>
+        </ezconfig>
+      </ezembed>
+      <ezconfig>
+        <ezvalue key="parent">value1</ezvalue>
+      </ezconfig>
+    </ezembed>
+    <ezconfig>
+      <ezvalue key="custom">big</ezvalue>
+    </ezconfig>
+  </paragraph>
+</section>',
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+  <paragraph>Here is paragraph with child embed
+    <ezembed xlink:href="ezlocation://601">
+      <ezembed xlink:href="ezlocation://602">
+        <ezconfig>
+          <ezvalue key="nested">value2</ezvalue>
+        </ezconfig>
+      </ezembed>
+      <ezconfig>
+        <ezvalue key="parent">value1</ezvalue>
+      </ezconfig>
+      <ezpayload><![CDATA[601]]></ezpayload>
+    </ezembed>
+    <ezconfig>
+      <ezvalue key="custom">big</ezvalue>
+    </ezconfig>
+  </paragraph>
+</section>',
+                [],
+                [
+                    [
+                        'method' => 'renderLocationEmbed',
+                        'id' => '601',
+                        'viewType' => 'embed',
+                        'is_inline' => false,
+                        'embedParams' => [
+                            'id' => '601',
+                            'viewType' => 'embed',
+                            'config' => [
+                                'parent' => 'value1',
                             ],
                         ],
                     ],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30631](https://jira.ez.no/browse/EZP-30631)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | latest stable
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Right now `getElementsByTagName` is used to fetch element's `ezconfig`. This kind config is used in different cases:
- custom attributes
- embed/custom tags parameters

Right now strange results sometimes are shown In cases when there are multiple nested elements with `ezconfig`. It happens because `getElementsByTagName` returns random (first?) `ezconfig` element. Instead, the first level child `ezconfig` should be returned. This PR fixes it.

1. Setup 2 custom tags: *custom_a* and *custom_b*. Both of them need to have own parameters set.
2. Start to edit any content with Rich Text field.
3. Add *custom_a* tag to any Richt Text field and set its parameters. 
4. Add *custom_b* tag Inside *custom_a*. Set some parameters for *custom_b*.
5. Save the changes.
6. Open the edited content on the front-end, and params of the nested custom tag (step 4) will be used to render the parent custom tag (step 3).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
