### PR TITLE
EZP-30628: Soft return inside inline style is removed after edit

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -729,7 +729,7 @@
     <xsl:apply-templates select="node()|@*"/>
   </xsl:template>
 
-  <xsl:template match="docbook:eztemplateinline/docbook:ezcontent/text()">
+  <xsl:template match="docbook:literallayout/docbook:eztemplateinline/docbook:ezcontent/text()">
     <xsl:call-template name="breakLine">
       <xsl:with-param name="text" select="."/>
     </xsl:call-template>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -729,6 +729,12 @@
     <xsl:apply-templates select="node()|@*"/>
   </xsl:template>
 
+  <xsl:template match="docbook:eztemplateinline/docbook:ezcontent/text()">
+    <xsl:call-template name="breakLine">
+      <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+
   <xsl:template name="extractStyleValue">
     <xsl:param name="style"/>
     <xsl:param name="property"/>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/032-ezstyleinline.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/032-ezstyleinline.xml
@@ -4,5 +4,8 @@
          xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
          xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
          version="5.0-variant ezpublish-1.0">
-    <para>Some <eztemplateinline type="style" name="highlighted_word"><ezcontent>highlighted words</ezcontent></eztemplateinline> for the otherwise unremarkable paragraph.</para>
+    <para>
+        <literallayout class="normal">Some <eztemplateinline type="style" name="highlighted_word"><ezcontent>highlighted words
+with line break</ezcontent></eztemplateinline> for the otherwise unremarkable paragraph.</literallayout>
+    </para>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/032-ezstyleinline.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/032-ezstyleinline.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-    <p>Some <span data-ezelement="eztemplateinline" data-eztype="style" data-ezname="highlighted_word">highlighted words</span> for the otherwise unremarkable paragraph.</p>
+    <p>Some <span data-ezelement="eztemplateinline" data-eztype="style" data-ezname="highlighted_word">highlighted words<br/>with line break</span> for the otherwise unremarkable paragraph.</p>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30628](https://jira.ez.no/browse/EZP-30628)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Soft return placed in the text wrapped with custom style isn't preserved after switching to edit mode. Related to https://github.com/ezsystems/ezplatform-richtext/pull/34 (proper rendering in view mode).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
