### PR TITLE
Fixed issues related to Kernel RichText code drop

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
+++ b/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
@@ -24,13 +24,13 @@ class RichTextHtml5ConverterPass implements CompilerPassInterface
     {
         if ($container->hasDefinition('ezrichtext.converter.output.xhtml5')) {
             $html5OutputConverterDefinition = $container->getDefinition('ezrichtext.converter.output.xhtml5');
-            $taggedOutputServiceIds = $container->findTaggedServiceIds('ezpublish.ezrichtext.converter.output.xhtml5');
+            $taggedOutputServiceIds = $container->findTaggedServiceIds('ezrichtext.converter.output.xhtml5');
             $this->setConverterDefinitions($taggedOutputServiceIds, $html5OutputConverterDefinition);
         }
 
         if ($container->hasDefinition('ezrichtext.converter.input.xhtml5')) {
             $html5InputConverterDefinition = $container->getDefinition('ezrichtext.converter.input.xhtml5');
-            $taggedInputServiceIds = $container->findTaggedServiceIds('ezpublish.ezrichtext.converter.input.xhtml5');
+            $taggedInputServiceIds = $container->findTaggedServiceIds('ezrichtext.converter.input.xhtml5');
             $this->setConverterDefinitions($taggedInputServiceIds, $html5InputConverterDefinition);
         }
     }

--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -48,7 +48,7 @@ services:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Converter\Link
         arguments: ['@ezpublish.api.service.location', '@ezpublish.api.service.content', '@ezpublish.urlalias_router', '@?logger']
         tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 0}
+            - {name: ezrichtext.converter.output.xhtml5, priority: 0}
 
     ezrichtext.converter.template:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render\Template
@@ -57,7 +57,7 @@ services:
             - '@ezrichtext.converter.output.xhtml5'
             - '@?logger'
         tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 10}
+            - {name: ezrichtext.converter.output.xhtml5, priority: 10}
         lazy: true
 
     ezrichtext.converter.embed:
@@ -66,14 +66,14 @@ services:
             - '@ezrichtext.renderer'
             - '@?logger'
         tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 10}
+            - {name: ezrichtext.converter.output.xhtml5, priority: 10}
 
     # Note: should typically be the last one as it produces embeddable fragment
     ezrichtext.converter.output.xhtml5.fragment:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Converter\Xslt
         arguments: ['%ezrichtext.converter.output.xhtml5.fragment.resources%']
         tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 100}
+            - {name: ezrichtext.converter.output.xhtml5, priority: 100}
 
     # Aggregate converter for XHTML5 output that other converters register to
     # through service tags.
@@ -117,10 +117,10 @@ services:
             - '%ezrichtext.converter.output.xhtml5.resources%'
             - '@ezpublish.config.resolver'
         tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 50}
+            - {name: ezrichtext.converter.output.xhtml5, priority: 50}
 
     # Aggregate converter for XHTML5 input that other converters register to
-    # through 'ezpublish.ezrichtext.converter.input.xhtml5' service tag.
+    # through 'ezrichtext.converter.input.xhtml5' service tag.
     ezrichtext.converter.input.xhtml5:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Converter\Aggregate
         lazy: true
@@ -131,13 +131,13 @@ services:
             - '%ezrichtext.converter.input.xhtml5.resources%'
             - '@ezpublish.config.resolver'
         tags:
-            - {name: ezpublish.ezrichtext.converter.input.xhtml5, priority: 50}
+            - {name: ezrichtext.converter.input.xhtml5, priority: 50}
 
     # Note: should run before xsl transformation
     ezrichtext.converter.input.xhtml5.programlisting:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Converter\ProgramListing
         tags:
-            - {name: ezpublish.ezrichtext.converter.input.xhtml5, priority: 10}
+            - {name: ezrichtext.converter.input.xhtml5, priority: 10}
 
     ezrichtext.converter.edit.xhtml5:
         class: EzSystems\EzPlatformRichTextBundle\eZ\RichText\Converter\Html5Edit

--- a/src/lib/eZ/FieldType/RichText/Type.php
+++ b/src/lib/eZ/FieldType/RichText/Type.php
@@ -277,7 +277,7 @@ class Type extends FieldType
     {
         $relations = [];
 
-        /** @var \eZ\Publish\Core\FieldType\RichText\Value $value */
+        /** @var \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value $value */
         if ($value->xml instanceof DOMDocument) {
             $relations = $this->inputHandler->getRelations($value->xml);
         }

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/fragment.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/fragment.xsl
@@ -6,7 +6,7 @@
     version="1.0">
 
   <!-- XSL stylesheets are dynamically added to this one via <xsl:import/> -->
-  <!-- See eZ\Publish\Core\FieldType\RichText\Converter\Xslt::getXSLTProcessor() -->
+  <!-- See \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Xslt::getXSLTProcessor() -->
   <!--<xsl:import href="core.xsl"/>-->
 
   <xsl:output omit-xml-declaration="yes" indent="yes" encoding="UTF-8"/>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/xhtml5.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/xhtml5.xsl
@@ -6,7 +6,7 @@
     version="1.0">
 
   <!-- XSL stylesheets are dynamically added to this one via <xsl:import/> -->
-  <!-- See eZ\Publish\Core\FieldType\RichText\Converter\Xslt::getXSLTProcessor() -->
+  <!-- See \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Xslt::getXSLTProcessor() -->
   <!--<xsl:import href="core.xsl"/>-->
 
   <xsl:output indent="yes" encoding="UTF-8"/>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/fragment.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/fragment.xsl
@@ -6,7 +6,7 @@
     version="1.0">
 
   <!-- XSL stylesheets are dynamically added to this one via <xsl:import/> -->
-  <!-- See eZ\Publish\Core\FieldType\RichText\Converter\Xslt::getXSLTProcessor() -->
+  <!-- See \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Xslt::getXSLTProcessor() -->
   <!--<xsl:import href="core.xsl"/>-->
 
   <xsl:output omit-xml-declaration="yes" indent="yes" encoding="UTF-8"/>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/xhtml5.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/xhtml5.xsl
@@ -6,7 +6,7 @@
     version="1.0">
 
   <!-- XSL stylesheets are dynamically added to this one via <xsl:import/> -->
-  <!-- See eZ\Publish\Core\FieldType\RichText\Converter\Xslt::getXSLTProcessor() -->
+  <!-- See \EzSystems\EzPlatformRichText\eZ\RichText\Converter\Xslt::getXSLTProcessor() -->
   <!--<xsl:import href="core.xsl"/>-->
 
   <xsl:output indent="yes" encoding="UTF-8"/>

--- a/src/lib/eZ/settings/fieldtype_services.yaml
+++ b/src/lib/eZ/settings/fieldtype_services.yaml
@@ -1,8 +1,5 @@
 parameters:
-    ezrichtext.resources: '%ezpublish.kernel.root_dir%/eZ/Publish/Core/FieldType/RichText/Resources'
-    ezrichtext.validator.docbook.resources:
-        - '%ezrichtext.resources%/schemas/docbook/ezpublish.rng'
-        - '%ezrichtext.resources%/schemas/docbook/docbook.iso.sch.xsl'
+    ezrichtext.validator.docbook.resources: []
 
 services:
     _defaults:

--- a/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\Tests\EzPlatformRichTextBundle\DependencyInjection\Compiler;
 
-use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RichTextHtml5ConverterPass;
+use EzSystems\EzPlatformRichTextBundle\DependencyInjection\Compiler\RichTextHtml5ConverterPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -21,6 +21,8 @@ class RichTextHtml5ConverterPassTest extends AbstractCompilerPassTestCase
      * method:.
      *
      *   $container->addCompilerPass(new MyCompilerPass());
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      */
     protected function registerCompilerPass(ContainerBuilder $container)
     {
@@ -31,30 +33,30 @@ class RichTextHtml5ConverterPassTest extends AbstractCompilerPassTestCase
     {
         $configurationResolver = new Definition();
         $this->setDefinition(
-            'ezpublish.fieldType.ezrichtext.converter.output.xhtml5',
+            'ezrichtext.converter.output.xhtml5',
             $configurationResolver
         );
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezpublish.ezrichtext.converter.output.xhtml5');
+        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5');
         $this->setDefinition('ezrichtext.converter.test1', $configurationProvider);
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezpublish.ezrichtext.converter.output.xhtml5', ['priority' => 10]);
+        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5', ['priority' => 10]);
         $this->setDefinition('ezrichtext.converter.test2', $configurationProvider);
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezpublish.ezrichtext.converter.output.xhtml5', ['priority' => 5]);
+        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5', ['priority' => 5]);
         $this->setDefinition('ezrichtext.converter.test3', $configurationProvider);
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezpublish.ezrichtext.converter.output.xhtml5', ['priority' => 5]);
+        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5', ['priority' => 5]);
         $this->setDefinition('ezrichtext.converter.test4', $configurationProvider);
 
         $this->compile();
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'ezpublish.fieldType.ezrichtext.converter.output.xhtml5',
+            'ezrichtext.converter.output.xhtml5',
             0,
             [
                 new Reference('ezrichtext.converter.test1'),

--- a/tests/bundle/DependencyInjection/EzPlatformRichTextExtensionTest.php
+++ b/tests/bundle/DependencyInjection/EzPlatformRichTextExtensionTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Yaml\Yaml;
 class EzPlatformRichTextExtensionTest extends AbstractExtensionTestCase
 {
     /**
-     * @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension
+     * @var \EzSystems\EzPlatformRichTextBundle\DependencyInjection\EzPlatformRichTextExtension
      */
     private $extension;
 

--- a/tests/integration/eZ/API/SetupFactory/RichTextSetupFactoryTrait.php
+++ b/tests/integration/eZ/API/SetupFactory/RichTextSetupFactoryTrait.php
@@ -30,6 +30,7 @@ trait RichTextSetupFactoryTrait
             throw new RuntimeException('Unable to find RichText package settings');
         }
 
+        // load core settings
         $loader = new YamlFileLoader($containerBuilder, new FileLocator($settingsPath));
         $loader->load('fieldtypes.yaml');
         $loader->load('fieldtype_services.yaml');
@@ -37,6 +38,13 @@ trait RichTextSetupFactoryTrait
         $loader->load('indexable_fieldtypes.yaml');
         $loader->load('storage_engines/legacy/external_storage_gateways.yaml');
         $loader->load('storage_engines/legacy/field_value_converters.yaml');
+
+        // load test settings
+        $loader = new YamlFileLoader(
+            $containerBuilder,
+            new FileLocator(__DIR__ . '/../../../../lib/eZ/settings')
+        );
+        $loader->load('common.yaml');
 
         $containerBuilder->addCompilerPass(new Compiler\RichTextHtml5ConverterPass());
     }

--- a/tests/lib/eZ/Persistence/Legacy/RichTextFieldValueConverterTest.php
+++ b/tests/lib/eZ/Persistence/Legacy/RichTextFieldValueConverterTest.php
@@ -10,7 +10,7 @@ namespace EzSystems\EzPlatformRichText\eZ\Persistence\Legacy\Tests\Content\Field
 
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter;
+use EzSystems\EzPlatformRichText\eZ\Persistence\Legacy\RichTextFieldValueConverter;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
 class RichTextFieldValueConverterTest extends TestCase
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter
+     * @var \EzSystems\EzPlatformRichText\eZ\Persistence\Legacy\RichTextFieldValueConverter
      */
     protected $converter;
 
@@ -34,7 +34,7 @@ class RichTextFieldValueConverterTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->converter = new RichTextConverter();
+        $this->converter = new RichTextFieldValueConverter();
         $this->docbookString = <<<EOT
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
@@ -52,7 +52,7 @@ EOT;
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter::toStorageValue
+     * @covers \EzSystems\EzPlatformRichText\eZ\Persistence\Legacy\RichTextFieldValueConverter::toStorageValue
      */
     public function testToStorageValue()
     {
@@ -65,7 +65,7 @@ EOT;
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter::toFieldValue
+     * @covers \EzSystems\EzPlatformRichText\eZ\Persistence\Legacy\RichTextFieldValueConverter::toFieldValue
      */
     public function testToFieldValue()
     {
@@ -75,29 +75,5 @@ EOT;
 
         $this->converter->toFieldValue($storageFieldValue, $fieldValue);
         self::assertSame($this->docbookString, $fieldValue->data);
-    }
-
-    /**
-     * @param string $relativePath
-     *
-     * @return string
-     */
-    protected function getAbsolutePath($relativePath)
-    {
-        return self::getInstallationDir() . '/' . $relativePath;
-    }
-
-    /**
-     * @return string
-     */
-    protected static function getInstallationDir()
-    {
-        static $installDir = null;
-        if ($installDir === null) {
-            $config = require 'config.php';
-            $installDir = $config['service']['parameters']['install_dir'];
-        }
-
-        return $installDir;
     }
 }

--- a/tests/lib/eZ/settings/common.yaml
+++ b/tests/lib/eZ/settings/common.yaml
@@ -1,4 +1,9 @@
 parameters:
+    ezrichtext.resources: 'src/lib/eZ/RichText/Resources'
+    ezrichtext.validator.docbook.resources:
+        - '%ezrichtext.resources%/schemas/docbook/ezpublish.rng'
+        - '%ezrichtext.resources%/schemas/docbook/docbook.iso.sch.xsl'
+
     ezplatform.ezrichtext.custom_tags:
         video:
             template: 'MyBundle:FieldType/RichText/tag:video.html.twig'


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30517](https://jira.ez.no/browse/EZP-30517), [EZP-28009](https://jira.ez.no/browse/EZP-28009)
| **Bug/Improvement**| yes
| **Required by** | ezsystems/ezpublish-kernel#2659
| **New feature**    | no
| **Target version** | `master (2.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | no

**This is a cumulative PR to be merged in a fast-forward way.**

This PR contains left-over fixes for obsolete parts of code related to [EZP-30517](https://jira.ez.no/browse/EZP-30517) and [EZP-28009](https://jira.ez.no/browse/EZP-28009):
- [x] Drops deprecated Kernel RichText Input/Output Converter tags 
  - `ezpublish.ezrichtext.converter.output.xhtml5` becomes `ezrichtext.converter.output.xhtml5`,
  - `ezpublish.ezrichtext.converter.input.xhtml5` becomes `ezrichtext.converter.input.xhtml5`.
  which is also a part of Product rebranding.
- [x] Fixes obsolete type-hints from Kernel RichText implementation that were missed during the initial work on [EZP-28009](https://jira.ez.no/browse/EZP-28009).

**TODO**:
- [x] **Before merge**: drop **TMP** commits and rebase after confirming CI passes.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for CI.
- [x] Ask for Code Review.
