### PR TITLE
EZP-30791: allow dashes in custom tag names

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -55,6 +55,7 @@ class Configuration extends SiteAccessConfiguration
     {
         return $ezRichTextNode
                 ->arrayNode('custom_tags')
+                ->normalizeKeys(false)
                 // workaround: take into account Custom Tag names when merging configs
                 ->useAttributeAsKey('tag')
                 ->arrayPrototype()


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30791](https://jira.ez.no/browse/EZP-30791)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.1`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Create a new `custom-tag-test` custom tag and enable it (following [this steps](https://doc.ezplatform.com/en/latest/guide/extending_online_editor/#custom-tags)).

Expected result: new custom tag is added to online editor

Actual result: error message about missing custom tag declaration.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
