### PR TITLE
EZP-30730: Narrowed "LF to <br>" XSLT to literallayout scope

### DIFF
--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -23,6 +23,8 @@ use Psr\Log\NullLogger;
  */
 class Template extends Render implements Converter
 {
+    const LITERAL_LAYOUT_LINE_BREAK = "\n";
+
     /**
      * @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter
      */
@@ -235,7 +237,7 @@ class Template extends Render implements Converter
      */
     private function wrapContentWithLiteralLayout(DOMNode $rootNode, DOMNode $node): DOMNode
     {
-        if (false === strpos($node->nodeValue, "\n")) {
+        if (false === strpos($node->nodeValue, self::LITERAL_LAYOUT_LINE_BREAK)) {
             return $rootNode;
         }
 

--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -235,20 +235,22 @@ class Template extends Render implements Converter
      */
     private function wrapContentWithLiteralLayout(DOMNode $rootNode, DOMNode $node): DOMNode
     {
-        $xpath = new DOMXPath($node->ownerDocument);
-        $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
-        if (
-            strpos($node->nodeValue, "\n") !== false
-            && $xpath->query('.//docbook:literallayout', $node)->length === 0
-        ) {
-            $literalLayoutNode = $rootNode->ownerDocument->createElementNS(
-                'http://docbook.org/ns/docbook',
-                'literallayout'
-            );
-
-            return $rootNode->appendChild($literalLayoutNode);
+        if (false === strpos($node->nodeValue, "\n")) {
+            return $rootNode;
         }
 
-        return $rootNode;
+        $xpath = new DOMXPath($node->ownerDocument);
+        $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
+
+        if ($xpath->query('.//docbook:literallayout', $node)->length > 0) {
+            return $rootNode;
+        }
+
+        $literalLayoutNode = $rootNode->ownerDocument->createElementNS(
+            'http://docbook.org/ns/docbook',
+            'literallayout'
+        );
+
+        return $rootNode->appendChild($literalLayoutNode);
     }
 }

--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -189,6 +189,8 @@ class Template extends Render implements Converter
         $rootNode = $innerDoc->createElementNS('http://docbook.org/ns/docbook', 'section');
         $innerDoc->appendChild($rootNode);
 
+        $rootNode = $this->wrapContentWithLiteralLayout($rootNode, $node);
+
         /** @var \DOMNode $child */
         foreach ($node->childNodes as $child) {
             $newNode = $innerDoc->importNode($child, true);
@@ -220,5 +222,33 @@ class Template extends Render implements Converter
         }
 
         return $this->extractHash($configElements->item(0));
+    }
+
+    /**
+     * BC: wrap nested content containing line breaks with "literallayout" DocBook tag,
+     * unless literallayout already exists.
+     *
+     * @param \DOMNode $rootNode
+     * @param \DOMNode $node
+     *
+     * @return \DOMNode
+     */
+    private function wrapContentWithLiteralLayout(DOMNode $rootNode, DOMNode $node): DOMNode
+    {
+        $xpath = new DOMXPath($node->ownerDocument);
+        $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
+        if (
+            strpos($node->nodeValue, "\n") !== false
+            && $xpath->query('.//docbook:literallayout', $node)->length === 0
+        ) {
+            $literalLayoutNode = $rootNode->ownerDocument->createElementNS(
+                'http://docbook.org/ns/docbook',
+                'literallayout'
+            );
+
+            return $rootNode->appendChild($literalLayoutNode);
+        }
+
+        return $rootNode;
     }
 }

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -719,7 +719,8 @@
     <xsl:apply-templates select="node()|@*"/>
   </xsl:template>
 
-  <xsl:template match="docbook:eztemplate/docbook:ezcontent/text()">
+  <!-- Content with line breaks should be wrapped with literallayout, treating entire content as literal due to BC -->
+  <xsl:template match="docbook:eztemplate/docbook:ezcontent/text() | docbook:eztemplate/docbook:ezcontent/docbook:literallayout/text()">
     <xsl:call-template name="breakLine">
       <xsl:with-param name="text" select="."/>
     </xsl:call-template>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -58,10 +58,10 @@
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="docbook:section/text()">
-      <xsl:call-template name="breakLine">
-        <xsl:with-param name="text" select="."/>
-      </xsl:call-template>
+  <xsl:template match="docbook:section/docbook:literallayout">
+    <xsl:call-template name="breakLine">
+      <xsl:with-param name="text" select="node()"/>
+    </xsl:call-template>
   </xsl:template>
 
   <xsl:template match="docbook:para">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -708,9 +708,22 @@
         <!-- Nest content of Style tag in ezcontent -->
         <xsl:when test="@data-eztype='style'">
           <xsl:element name="ezcontent" namespace="http://docbook.org/ns/docbook">
-            <xsl:call-template name="breakline">
-              <xsl:with-param name="node" select="node()"/>
-            </xsl:call-template>
+            <xsl:choose>
+              <xsl:when test="@data-ezelement='eztemplate' and descendant::ezxhtml5:br">
+                <!-- Wrap with literallayout only block custom styles -->
+                <xsl:element name="literallayout">
+                  <xsl:call-template name="breakline">
+                    <xsl:with-param name="node" select="node()"/>
+                  </xsl:call-template>
+                </xsl:element>
+              </xsl:when>
+              <xsl:otherwise>
+                <!-- Inline custom styles already have outer literallayout for e.g. para -->
+                <xsl:call-template name="breakline">
+                  <xsl:with-param name="node" select="node()"/>
+                </xsl:call-template>
+              </xsl:otherwise>
+            </xsl:choose>
           </xsl:element>
         </xsl:when>
         <!-- For other types of tags behave as usual (ezcontent should be defined explicitly) -->

--- a/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
@@ -294,5 +294,17 @@ class TemplateTest extends TestCase
                 ],
             ],
         ],
+        '08-line-breaks' => [
+            [
+                'name' => 'template8',
+                'type' => 'tag',
+                'is_inline' => false,
+                'params' => [
+                    'name' => 'template8',
+                    'content' => "<literallayout>Some content\nwith line breaks.</literallayout>",
+                    'params' => [],
+                ],
+            ],
+        ],
     ];
 }

--- a/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/input/08-line-breaks.xml
+++ b/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/input/08-line-breaks.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook">
+  <eztemplate name="template8">
+    <ezcontent>Some content
+with line breaks.</ezcontent>
+  </eztemplate>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/output/08-line-breaks.xml
+++ b/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/output/08-line-breaks.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook">
+  <eztemplate name="template8">
+    <ezcontent>Some content
+with line breaks.</ezcontent>
+    <ezpayload><![CDATA[template8]]></ezpayload>
+  </eztemplate>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/031-ezstyle.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/031-ezstyle.xml
@@ -14,10 +14,9 @@
         <ezcontent>Highlighted block with "center" align.</ezcontent>
     </eztemplate>
     <eztemplate name="highlighted_block" type="style">
-        <ezcontent>
-            Highlighted block with multiple lines
-            Highlighted block with multiple lines
-            Highlighted block with multiple lines
+        <ezcontent><literallayout>Highlighted block with multiple lines
+Highlighted block with multiple lines
+Highlighted block with multiple lines</literallayout>
         </ezcontent>
     </eztemplate>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/031-ezstyle.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/031-ezstyle.xml
@@ -3,5 +3,5 @@
     <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" data-ezalign="left">Highlighted block with "left" align.</div>
     <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" data-ezalign="right">Highlighted block with "right" align.</div>
     <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" data-ezalign="center">Highlighted block with "center" align.</div>
-    <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block"><br/>            Highlighted block with multiple lines<br/>            Highlighted block with multiple lines<br/>            Highlighted block with multiple lines<br/>        </div>
+    <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block">Highlighted block with multiple lines<br/>Highlighted block with multiple lines<br/>Highlighted block with multiple lines</div>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30730](https://jira.ez.no/browse/EZP-30730)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `v1.1.4` for eZ Platform `v2.5.4 LTS`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR narrows down the scope of applied transformation rendering HTML `<br>` tags for nested Custom Templates (Tags/Styles) content to `docbook:literallayout` contents.

The issue is that at the moment of applying transformation of `docbook:ezcontent`, for the sample Custom Style:
```xml
  <eztemplate name="style3" type="style">
    <ezcontent>Line
break
    </ezcontent>
  </eztemplate>
```
the processed on the fly XML has the form of:
```xml
<?xml version="1.0"?>\n
<section xmlns="http://docbook.org/ns/docbook">Line
break
</section>
```

The solution is to wrap block Custom Styles with `literallayout` when needed.

To achieve that the transformation from HTML5Edit transforms DocBook differently:

Before
```xml
<eztemplate name="style3" type="style">
    <ezcontent>Line
break
    </ezcontent>
```
After:
```xml
<eztemplate name="style3" type="style">
    <ezcontent><literallayout>Line
break</literallayout>
    </ezcontent>
```

It's needed for block Custom Styles only, because inline Custom Templates are already wrapped by transformations outer block elements:
```xml
<para>
    <literallayout>
        <eztemplateinline>
            ...
        </eztemplateinline>
    </literallayout>
</para>
```

Moreover block Custom Tags allow inserting block elements only, so specific block element transformation is already applied, as in the case above.

### BC

For backward compatibility reasons the following stored XML:
```xml
<eztemplate name="style3" type="style">
    <ezcontent>Line
break
    </ezcontent>
```
needs to produce proper line breaks for the output as well.

Given that the previous implementation applied line breaking transformation to `section/text()`, entire `ezcontent` is wrapped with `literallayout` tag, unless it explicitly contains that tag.

### Background

Providing this verbatim payload as RichText Field Value `DOMDocument`:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
         version="5.0-variant ezpublish-1.0">
  <para>
Text
  </para>
```
results in the following output HTML:
```html
<br>
<p>
<br>
Text
<br>
</p>
<br>
```
This is a side effect of CSR-required change introduced via #34 for Custom Templates due to unavailability of outer scope when processing `ezcontent` of a Template (as described in the previous section).

The eZ Platform DocBook spec defines `literallayout` as the only tag where `breakline` transformation should be applied, so current behavior is incorrect. Wrapping literal `ezcontent` with `literallayout` solves that challenge as applying line breaking transformation on `section/literallayout` is correct with respect to the specification.

### QA

The bug is visible with eZ Platform EE Demo `2.5` on the landing page inside block of "Top Place to Go". It renders `<br>` which makes content a little bit misaligned.

Please test against regressions to [EZP-29876](https://jira.ez.no/browse/EZP-29876) and [EZP-30628](https://jira.ez.no/browse/EZP-30628).

Please also test BC by storing RichText according to those JIRA tickets, and then checking out changes from this PR to see if w/o editing line breaks still exist. Please then see if editing is still possible.

Line breaks are applied to the following block and inline elements:
- paragraph,
- emphasis,
- table cell,
- Custom template (Style or Tag).

**TODO**:
- [x] Provide better PR description.
- [x] Narrow `LF` to `<br>` XSL transformation to Custom Tags/Styles inside `literallayout` only.
- [x] Provide BC for stored DocBook with Custom Styles.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
