### PR TITLE
EZP-30814: Removed Twig deprecations

### DIFF
--- a/src/bundle/Resources/views/RichText/style/default.html.twig
+++ b/src/bundle/Resources/views/RichText/style/default.html.twig
@@ -1,1 +1,1 @@
-<div class="{% if align is defined %}align-{{ align }}{% endif %} ezstyle-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</div>
+<div class="{% if align is defined %}align-{{ align }}{% endif %} ezstyle-{{ name }}">{% apply spaceless %}{{ content|raw }}{% endapply %}</div>

--- a/src/bundle/Resources/views/RichText/style/default_inline.html.twig
+++ b/src/bundle/Resources/views/RichText/style/default_inline.html.twig
@@ -1,1 +1,1 @@
-<span class="ezstyle-{{ name }}">{% spaceless %}{{ content|raw }}{% endspaceless %}</span>
+<span class="ezstyle-{{ name }}">{% apply spaceless %}{{ content|raw }}{% endapply %}</span>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30814](https://jira.ez.no/browse/EZP-30814)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Continuation of https://github.com/ezsystems/ezpublish-kernel/pull/2708: replaced `spaceless` tag usages in favour of `spaceless` filter

**TODO**:
- [X] Implement feature / fix a bug.
- [ ] ~Implement tests.~
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
