### PR TITLE
EZP-30732: Allows table cells to contain inlines and blocks

### DIFF
--- a/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -462,30 +462,6 @@
     <define name="db.wordasword"><notAllowed/></define>
     <define name="db.xref"><notAllowed/></define>
     <define name="db.year"><notAllowed/></define>
-
-    <define name="db.html.th">
-      <element name="th">
-        <a:documentation>A table header entry in an HTML table</a:documentation>
-        <ref name="db.html.th.attlist"/>
-        <zeroOrMore>
-          <choice>
-            <ref name="db.all.inlines"/>
-            <ref name="db.all.blocks"/>
-          </choice>
-        </zeroOrMore>
-      </element>
-    </define>
-    <define name="db.html.td">
-      <element name="td">
-        <a:documentation>A table entry in an HTML table</a:documentation>
-        <zeroOrMore>
-          <choice>
-            <ref name="db.all.inlines"/>
-            <ref name="db.all.blocks"/>
-          </choice>
-        </zeroOrMore>
-      </element>
-    </define>
   </include>
 
   <define name="ez.db.section">
@@ -854,6 +830,30 @@
         <ref name="ez.config.hash"/>
       </element>
     </optional>
+  </define>
+
+  <define name="db.html.th" combine="choice">
+    <element name="th">
+      <a:documentation>A table header entry in an HTML table</a:documentation>
+      <ref name="db.html.th.attlist"/>
+      <zeroOrMore>
+        <choice>
+          <ref name="db.all.inlines"/>
+          <ref name="db.all.blocks"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+  <define name="db.html.td" combine="choice">
+    <element name="td">
+      <a:documentation>A table entry in an HTML table</a:documentation>
+      <zeroOrMore>
+        <choice>
+          <ref name="db.all.inlines"/>
+          <ref name="db.all.blocks"/>
+        </choice>
+      </zeroOrMore>
+    </element>
   </define>
 
   <div>

--- a/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -462,6 +462,30 @@
     <define name="db.wordasword"><notAllowed/></define>
     <define name="db.xref"><notAllowed/></define>
     <define name="db.year"><notAllowed/></define>
+
+    <define name="db.html.th">
+      <element name="th">
+        <a:documentation>A table header entry in an HTML table</a:documentation>
+        <ref name="db.html.th.attlist"/>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.all.inlines"/>
+            <ref name="db.all.blocks"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
+    <define name="db.html.td">
+      <element name="td">
+        <a:documentation>A table entry in an HTML table</a:documentation>
+        <zeroOrMore>
+          <choice>
+            <ref name="db.all.inlines"/>
+            <ref name="db.all.blocks"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+    </define>
   </include>
 
   <define name="ez.db.section">

--- a/tests/lib/eZ/RichText/Validator/DocbookTest.php
+++ b/tests/lib/eZ/RichText/Validator/DocbookTest.php
@@ -114,6 +114,25 @@ class DocbookTest extends TestCase
 </section>',
                 [],
             ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section
+    xmlns="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+    xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <informaltable width="100%" border="1">
+        <tbody>
+            <tr>
+                <td>
+                    <blockquote/>
+                </td>
+            </tr>
+        </tbody>
+    </informaltable>
+</section>',
+                [],
+            ],
         ];
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30732](https://jira.ez.no/browse/EZP-30732)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.1`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Seems like there is a bug in `doocbook.rng`:
```
    <define name="db.html.td">
      <element name="td">
        <a:documentation>A table entry in an HTML table</a:documentation>
        <ref name="db.html.td.attlist"/>
        <choice>
          <zeroOrMore>
            <ref name="db.all.inlines"/>
          </zeroOrMore>
          <zeroOrMore>
            <ref name="db.all.blocks"/>
          </zeroOrMore>
        </choice>
      </element>
    </define>
```

The fist condition is always true:
```
          <zeroOrMore>
            <ref name="db.all.inlines"/>
          </zeroOrMore>
```
And thats if table cell cotnains any `db.all.blocks` - triggers a validation error:
`Validation of XML content failed`

The most correct fix would be to make this change in `doocbook.rng`.

This PR is related to https://github.com/ezsystems/ezplatform-admin-ui/pull/1034.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
