### PR TITLE
[Composer] Added direct ezsystems/doctrine-dbal-schema dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,6 @@
     "homepage": "https://ezplatform.com",
     "license": "GPL-2.0-only",
     "type": "ezplatform-bundle",
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
         "php": "^7.3",
         "ext-xsl": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/validator": "^4.3",
         "symfony/cache": "^4.3",
         "twig/twig": "^2.11",
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "ezsystems/ezpublish-kernel": "^8.0@dev",
         "ezsystems/repository-forms": "^3.0@dev",
         "ezsystems/ezplatform-rest": "^1.0@dev"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

Tests in https://github.com/ezsystems/ezplatform-richtext/pull/53 are failing (example: https://travis-ci.org/ezsystems/ezplatform-richtext/jobs/569217334) with error:
```
1) EzSystems\IntegrationTests\EzPlatformRichText\eZ\API\RichTextFieldTypeIntegrationTest::testFromHash with data set #0 (array('<?xml version="1.0" encoding=...ion>\n'))

Cannot create a repository with predefined user. Check the UserService or RoleService implementation. 

Exception: Symfony\Component\Config\Exception\FileLocatorFileNotFoundException: The file "repository/event.yml" does not exist (in: /home/travis/build/ezsystems/ezplatform-richtext/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/settings). in /home/travis/build/ezsystems/ezplatform-richtext/vendor/symfony/config/FileLocator.php:71
```

The file exists in master (https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/settings/repository/event.yml) but not in ezpublish-kernel:8.0.0-beta1 , which is downloaded with current dependency setup:
```
- Installing ezsystems/ezpublish-kernel (v8.0.0-beta1): Loading from cache
- Installing ezsystems/repository-forms (v3.0.0-beta1): Loading from cache
```

Removing minimum-stability and prefer-stable options allows to install ezpublish-kernel:dev-master, but then a direct dependency on `ezsystems/doctrine-dbal-schema` has to be added (otherwise Composer will fail, as ezsystems/doctrine-dbal-schema does not have a stable version to install).