### PR TITLE
[Twig] Renamed RichTextExtension to RichTextConverterExtension

### DIFF
--- a/src/bundle/Resources/config/templating.yaml
+++ b/src/bundle/Resources/config/templating.yaml
@@ -1,7 +1,10 @@
 services:
-    EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension\RichTextExtension:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension\RichTextConverterExtension:
         arguments:
-            - '@ezrichtext.converter.output.xhtml5'
-            - '@ezrichtext.converter.edit.xhtml5'
-        tags:
-            - { name: twig.extension }
+            $richTextOutputConverter: '@ezrichtext.converter.output.xhtml5'
+            $richTextEditConverter: '@ezrichtext.converter.edit.xhtml5'

--- a/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
+++ b/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
@@ -8,34 +8,33 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension;
 
+use DOMDocument;
 use EzSystems\EzPlatformRichText\eZ\RichText\Converter as RichTextConverterInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
-class RichTextExtension extends AbstractExtension
+class RichTextConverterExtension extends AbstractExtension
 {
-    /**
-     * @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter
-     */
-    private $richTextConverter;
+    /** @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter */
+    private $richTextOutputConverter;
 
-    /**
-     * @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter
-     */
+    /** @var \EzSystems\EzPlatformRichText\eZ\RichText\Converter */
     private $richTextEditConverter;
 
-    public function __construct(RichTextConverterInterface $richTextConverter, RichTextConverterInterface $richTextEditConverter)
-    {
-        $this->richTextConverter = $richTextConverter;
+    public function __construct(
+        RichTextConverterInterface $richTextOutputConverter,
+        RichTextConverterInterface $richTextEditConverter
+    ) {
+        $this->richTextOutputConverter = $richTextOutputConverter;
         $this->richTextEditConverter = $richTextEditConverter;
     }
 
-    public function getName()
+    public function getName(): string
     {
-        return 'ezpublish.rich_text';
+        return 'ezrichtext.converter';
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter(
@@ -58,9 +57,9 @@ class RichTextExtension extends AbstractExtension
      *
      * @return string
      */
-    public function richTextToHtml5($xmlData)
+    public function richTextToHtml5(DOMDocument $xmlData): string
     {
-        return $this->richTextConverter->convert($xmlData)->saveHTML();
+        return $this->richTextOutputConverter->convert($xmlData)->saveHTML();
     }
 
     /**
@@ -70,7 +69,7 @@ class RichTextExtension extends AbstractExtension
      *
      * @return string
      */
-    public function richTextToHtml5Edit($xmlData)
+    public function richTextToHtml5Edit(DOMDocument $xmlData): string
     {
         return $this->richTextEditConverter->convert($xmlData)->saveHTML();
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Discovered when working on [EZP-30393](https://jira.ez.no/browse/EZP-30393)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (2.0)` for eZ Platform `v3.0`
| **BC breaks**      | no[1]
| **Tests pass**     | yes
| **Doc needed**     | no[1]

In order to prepare for separated responsibilities for each Twig extension (one more is comming with 
[EZP-30393](https://jira.ez.no/browse/EZP-30393)) this PR renames Twig `RichTextExtension` to `RichTextConverterExtension`.

It also introduces some refactoring aligning code style and naming conventions.

[1] End-developer was never supposed to inject `EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension\RichTextExtension` as it provides Twig filters and should be used for that purpose only, so there was never a BC promise for that.

**TODO**:
- [x] Rename `RichTextExtension` to `RichTextConverterExtension`.
- [x] Refactor `RichTextConverterExtension` to align code style and naming.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
