### PR TITLE
EZP-30798: Simplified DIC of Twig YoutubeIdExtractorExtension

### DIFF
--- a/src/bundle/Resources/config/templating.yaml
+++ b/src/bundle/Resources/config/templating.yaml
@@ -8,6 +8,5 @@ services:
         arguments:
             $richTextOutputConverter: '@ezrichtext.converter.output.xhtml5'
             $richTextEditConverter: '@ezrichtext.converter.edit.xhtml5'
-    EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension\YoutubeIdExtractorExtension:
-        tags:
-            - { name: twig.extension }
+
+    EzSystems\EzPlatformRichTextBundle\Templating\Twig\Extension\YoutubeIdExtractorExtension: ~


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow-up to [EZP-30798](https://jira.ez.no/browse/EZP-30798)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

With Symfony DIC auto-configuration enabled, explicit tagging of Twig extensions is not needed.

**TODO**:
- [x] Remove explicit tag from DIC config for YoutubeIdExtractorExtension.
- [x] Ask for Code Review.
