### PR TITLE
EZP-30845: XSLT processor can't find stylesheet and throws exception if project is running in a directory which name contains spaces 

### DIFF
--- a/src/lib/eZ/RichText/Converter/Xslt.php
+++ b/src/lib/eZ/RichText/Converter/Xslt.php
@@ -78,8 +78,7 @@ class Xslt extends XmlBase implements Converter
 
             // Prevents showing XSLTProcessor::importStylesheet() warning on Windows file system
             // & allows loading stylesheets if project's directory name contains space(s)
-            $hrefAttr->value = str_replace(['\\', ' '], ['/', '%20'], $stylesheet);
-
+            $hrefAttr->value = realpath($stylesheet);
             $newEl->appendChild($hrefAttr);
             $xslDoc->documentElement->insertBefore($newEl, $insertBeforeEl);
         }

--- a/src/lib/eZ/RichText/Converter/Xslt.php
+++ b/src/lib/eZ/RichText/Converter/Xslt.php
@@ -77,7 +77,8 @@ class Xslt extends XmlBase implements Converter
             $hrefAttr = $xslDoc->createAttribute('href');
 
             // Prevents showing XSLTProcessor::importStylesheet() warning on Windows file system
-            $hrefAttr->value = str_replace('\\', '/', $stylesheet);
+            // & allows loading stylesheets if project's directory name contains space(s)
+            $hrefAttr->value = str_replace(['\\', ' '], ['/', '%20'], $stylesheet);
 
             $newEl->appendChild($hrefAttr);
             $xslDoc->documentElement->insertBefore($newEl, $insertBeforeEl);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30845](https://jira.ez.no/browse/EZP-30845)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes bug described in the JIRA ticket. Please refer to the ticket for more information.

Related PR for 6.7/6.13: https://github.com/ezsystems/ezpublish-kernel/pull/2746

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
