### PR TITLE
EZP-30887: Optimized processing Custom Tag templates

### DIFF
--- a/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
@@ -130,7 +130,13 @@ class TemplateTest extends TestCase
 
     protected function getConverter()
     {
-        return new Template($this->rendererMock, $this->converterMock);
+        return new Template(
+            $this->rendererMock,
+            new Converter\Aggregate([
+                new Template($this->rendererMock, $this->converterMock),
+                $this->converterMock,
+            ])
+        );
     }
 
     /**
@@ -226,22 +232,22 @@ class TemplateTest extends TestCase
         ],
         '04-block-nested-template' => [
             [
-                'name' => 'template7',
+                'name' => 'template8',
                 'is_inline' => false,
                 'params' => [
-                    'name' => 'template7',
-                    'content' => 'content7<eztemplate name="template8"><ezcontent>content8</ezcontent></eztemplate>',
+                    'name' => 'template8',
+                    'content' => 'content8',
                     'params' => [
                     ],
                 ],
                 'content' => null,
             ],
             [
-                'name' => 'template8',
+                'name' => 'template7',
                 'is_inline' => false,
                 'params' => [
-                    'name' => 'template8',
-                    'content' => 'content8',
+                    'name' => 'template7',
+                    'content' => 'content7<eztemplate name="template8"><ezcontent>content8</ezcontent><ezpayload>template8</ezpayload></eztemplate>',
                     'params' => [
                     ],
                 ],

--- a/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/input/04-block-nested-template.xml
+++ b/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/input/04-block-nested-template.xml
@@ -2,7 +2,7 @@
 <section xmlns="http://docbook.org/ns/docbook">
   <eztemplate name="template7">
     <ezcontent>content7<eztemplate name="template8">
-    <ezcontent>content8</ezcontent>
-  </eztemplate></ezcontent>
+      <ezcontent>content8</ezcontent>
+    </eztemplate></ezcontent>
   </eztemplate>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/output/04-block-nested-template.xml
+++ b/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/output/04-block-nested-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://docbook.org/ns/docbook">
   <eztemplate name="template7">
-    <ezcontent>content7template8</ezcontent>
-    <ezpayload><![CDATA[template7]]></ezpayload>
+    <ezcontent>content7<eztemplate name="template8"><ezcontent>content8</ezcontent></eztemplate></ezcontent>
+    <ezpayload>template7</ezpayload>
   </eztemplate>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30887](https://jira.ez.no/browse/EZP-30887)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

On the first `convert` iteration, `$templates` variable contains all the templates (including nested custom tags).
But, there will be a new call of `convert` in `getCustomTemplateContent` function, which leads to the same template processed multiple times.
Extra calls count equal to custom tag depth.

### QA
- [ ] Sanities for rendering of nested Custom Tags

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.

P.S. Was found and fixed in related bundle https://gitlab.com/contextualcode/ezplatform-richtext-template-extension/commit/01bb8c75ff0be8470b7bc9e9c6b0e94e4c187c61

cc: @SerheyDolgushev 