### PR TITLE
Prefixed Service Tags with ezplatform to align with existing convention

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
+++ b/src/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPass.php
@@ -24,13 +24,13 @@ class RichTextHtml5ConverterPass implements CompilerPassInterface
     {
         if ($container->hasDefinition('ezrichtext.converter.output.xhtml5')) {
             $html5OutputConverterDefinition = $container->getDefinition('ezrichtext.converter.output.xhtml5');
-            $taggedOutputServiceIds = $container->findTaggedServiceIds('ezrichtext.converter.output.xhtml5');
+            $taggedOutputServiceIds = $container->findTaggedServiceIds('ezplatform.ezrichtext.converter.output.xhtml5');
             $this->setConverterDefinitions($taggedOutputServiceIds, $html5OutputConverterDefinition);
         }
 
         if ($container->hasDefinition('ezrichtext.converter.input.xhtml5')) {
             $html5InputConverterDefinition = $container->getDefinition('ezrichtext.converter.input.xhtml5');
-            $taggedInputServiceIds = $container->findTaggedServiceIds('ezrichtext.converter.input.xhtml5');
+            $taggedInputServiceIds = $container->findTaggedServiceIds('ezplatform.ezrichtext.converter.input.xhtml5');
             $this->setConverterDefinitions($taggedInputServiceIds, $html5InputConverterDefinition);
         }
     }

--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -83,13 +83,13 @@ services:
 
     ezrichtext.validator.input.ezxhtml5:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Validator\ValidatorAggregate
-        arguments: [!tagged ezrichtext.validator.input.ezxhtml5]
+        arguments: [!tagged ezplatform.ezrichtext.validator.input.ezxhtml5]
 
     ezrichtext.validator.docbook:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Validator\Validator
         arguments: ['%ezrichtext.validator.docbook.resources%']
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: 'ezplatform.ezrichtext.validator.input.ezxhtml5' }
 
     ezrichtext.validator.output.ezxhtml5:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Validator\Validator
@@ -109,7 +109,7 @@ services:
             - '@ezpublish.spi.persistence.cache.contentHandler'
             - '@ezpublish.spi.persistence.cache.locationHandler'
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: 'ezplatform.ezrichtext.validator.input.ezxhtml5' }
 
     ezrichtext.converter.output.xhtml5.core:
         class: EzSystems\EzPlatformRichTextBundle\eZ\RichText\Converter\Html5
@@ -120,7 +120,7 @@ services:
             - {name: ezrichtext.converter.output.xhtml5, priority: 50}
 
     # Aggregate converter for XHTML5 input that other converters register to
-    # through 'ezrichtext.converter.input.xhtml5' service tag.
+    # through 'ezplatform.ezrichtext.converter.input.xhtml5' service tag.
     ezrichtext.converter.input.xhtml5:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Converter\Aggregate
         lazy: true

--- a/src/lib/eZ/settings/fieldtype_services.yaml
+++ b/src/lib/eZ/settings/fieldtype_services.yaml
@@ -15,13 +15,13 @@ services:
 
     ezrichtext.validator.input.ezxhtml5:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Validator\ValidatorAggregate
-        arguments: [!tagged ezrichtext.validator.input.ezxhtml5]
+        arguments: [!tagged ezplatform.ezrichtext.validator.input.ezxhtml5]
 
     ezrichtext.validator.docbook:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Validator\Validator
         arguments: ['%ezrichtext.validator.docbook.resources%']
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: 'ezplatform.ezrichtext.validator.input.ezxhtml5' }
 
     ezrichtext.validator.input.dispatcher:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Validator\ValidatorDispatcher
@@ -35,7 +35,7 @@ services:
             - '@ezpublish.spi.persistence.cache.contentHandler'
             - '@ezpublish.spi.persistence.cache.locationHandler'
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: 'ezplatform.ezrichtext.validator.input.ezxhtml5' }
 
     ezrichtext.normalizer.input:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Normalizer\Aggregate
@@ -45,7 +45,7 @@ services:
         public: false
         arguments: ['%ezplatform.ezrichtext.custom_tags%']
         tags:
-            - { name: 'ezrichtext.validator.input.ezxhtml5' }
+            - { name: 'ezplatform.ezrichtext.validator.input.ezxhtml5' }
 
     EzSystems\EzPlatformRichText\eZ\RichText\RelationProcessor:
         public: false

--- a/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/RichTextHtml5ConverterPassTest.php
@@ -38,19 +38,19 @@ class RichTextHtml5ConverterPassTest extends AbstractCompilerPassTestCase
         );
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5');
+        $configurationProvider->addTag('ezplatform.ezrichtext.converter.output.xhtml5');
         $this->setDefinition('ezrichtext.converter.test1', $configurationProvider);
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5', ['priority' => 10]);
+        $configurationProvider->addTag('ezplatform.ezrichtext.converter.output.xhtml5', ['priority' => 10]);
         $this->setDefinition('ezrichtext.converter.test2', $configurationProvider);
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5', ['priority' => 5]);
+        $configurationProvider->addTag('ezplatform.ezrichtext.converter.output.xhtml5', ['priority' => 5]);
         $this->setDefinition('ezrichtext.converter.test3', $configurationProvider);
 
         $configurationProvider = new Definition();
-        $configurationProvider->addTag('ezrichtext.converter.output.xhtml5', ['priority' => 5]);
+        $configurationProvider->addTag('ezplatform.ezrichtext.converter.output.xhtml5', ['priority' => 5]);
         $this->setDefinition('ezrichtext.converter.test4', $configurationProvider);
 
         $this->compile();


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master (2.0@dev)` for eZ Platform `v3.0`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR adds `ezplatform.` prefix to all service tags provided by the RichText bundle to keep consistency with the other eZ Platform bundles.

### Open question

There are services defined by old naming scheme (instead of FQCN). All the names start with `ezrichtext.` as well. Should we also prefix them with `ezplatform.`?

Should we prefix in the same way parameters and Twig extension names?

### Documentation

Release notes and/or upgrade instructions should mention renamed service tags.

**TODO**:
- [ ] Merge #46 first.
- [x] Rename the service tag `ezrichtext.converter.output.xhtml5` to `ezplatform.ezrichtext.converter.output.xhtml5`.
- [x] Rename the service tag `ezrichtext.converter.input.xhtml5` to `ezplatform.ezrichtext.converter.input.xhtml5`.
- [x] Rename the service tag `ezrichtext.validator.input.ezxhtml5` to `ezplatform.ezrichtext.validator.input.ezxhtml5`.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
