### PR TITLE
EZP-30906: Removed deprecated templating component integration

### DIFF
--- a/src/bundle/Resources/config/default_settings.yaml
+++ b/src/bundle/Resources/config/default_settings.yaml
@@ -28,31 +28,31 @@ parameters:
     # RichText field type template tag settings
     # 'default' and 'default_inline' tag identifiers are reserved for fallback
     ezsettings.default.fieldtypes.ezrichtext.tags.default:
-        template: EzPlatformRichTextBundle:RichText/tag:default.html.twig
+        template: '@@EzPlatformRichText/RichText/tag/default.html.twig'
     ezsettings.default.fieldtypes.ezrichtext.tags.default_inline:
-        template: EzPlatformRichTextBundle:RichText/tag:default_inline.html.twig
+        template: '@@EzPlatformRichText/RichText/tag/default_inline.html.twig'
 
     # RichText field type template style settings
     # 'default' and 'default_inline' tag identifiers are reserved for fallback
     ezsettings.default.fieldtypes.ezrichtext.styles.default:
-        template: EzPlatformRichTextBundle:RichText/style:default.html.twig
+        template: '@@EzPlatformRichText/RichText/style/default.html.twig'
     ezsettings.default.fieldtypes.ezrichtext.styles.default_inline:
-        template: EzPlatformRichTextBundle:RichText/style:default_inline.html.twig
+        template: '@@EzPlatformRichText/RichText/style/default_inline.html.twig'
 
     # RichText field type embed settings
     ezsettings.default.fieldtypes.ezrichtext.embed.content:
-        template: EzPlatformRichTextBundle:RichText/embed:content.html.twig
+        template: '@@EzPlatformRichText/RichText/embed/content.html.twig'
     ezsettings.default.fieldtypes.ezrichtext.embed.content_denied:
-        template: EzPlatformRichTextBundle:RichText/embed:content_denied.html.twig
+        template: '@@EzPlatformRichText/RichText/embed/content_denied.html.twig'
     ezsettings.default.fieldtypes.ezrichtext.embed.content_inline:
-        template: EzPlatformRichTextBundle:RichText/embed:content_inline.html.twig
+        template: '@@EzPlatformRichText/RichText/embed/content_inline.html.twig'
     ezsettings.default.fieldtypes.ezrichtext.embed.content_inline_denied:
-        template: EzPlatformRichTextBundle:RichText/embed:content_inline_denied.html.twig
+        template: '@@EzPlatformRichText/RichText/embed/content_inline_denied.html.twig'
     ezsettings.default.fieldtypes.ezrichtext.embed.location:
-        template: EzPlatformRichTextBundle:RichText/embed:location.html.twig
+        template: '@@EzPlatformRichText/RichText/embed/location.html.twig'
     ezsettings.default.fieldtypes.ezrichtext.embed.location_denied:
-        template: EzPlatformRichTextBundle:RichText/embed:location_denied.html.twig
+        template: '@@EzPlatformRichText/RichText/embed/location_denied.html.twig'
     ezsettings.default.fieldtypes.ezrichtext.embed.location_inline:
-        template: EzPlatformRichTextBundle:RichText/embed:location_inline.html.twig
+        template: '@@EzPlatformRichText/RichText/embed/location_inline.html.twig'
     ezsettings.default.fieldtypes.ezrichtext.embed.location_inline_denied:
-        template: EzPlatformRichTextBundle:RichText/embed:location_inline_denied.html.twig
+        template: '@@EzPlatformRichText/RichText/embed/location_inline_denied.html.twig'

--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -36,7 +36,7 @@ services:
             - '@ezpublish.api.repository'
             - '@security.authorization_checker'
             - '@ezpublish.config.resolver'
-            - '@templating'
+            - '@twig'
             - '%ezrichtext.tag.namespace%'
             - '%ezrichtext.style.namespace%'
             - '%ezrichtext.embed.namespace%'

--- a/src/bundle/Resources/views/RichText/content_fields.html.twig
+++ b/src/bundle/Resources/views/RichText/content_fields.html.twig
@@ -1,6 +1,6 @@
 {% trans_default_domain "content_fields" %}
 
-{% extends "EzPublishCoreBundle::content_fields.html.twig" %}
+{% extends "@EzPublishCore/content_fields.html.twig" %}
 
 {% block ezrichtext_field %}
     {%- set field_value = field.value.xml|ez_richtext_to_html5 -%}

--- a/src/bundle/eZ/RichText/Renderer.php
+++ b/src/bundle/eZ/RichText/Renderer.php
@@ -13,7 +13,6 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformRichText\eZ\RichText\RendererInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -21,6 +20,7 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Exception;
 use Psr\Log\LoggerInterface;
+use Twig\Environment;
 
 /**
  * Symfony implementation of RichText field type embed renderer.
@@ -61,7 +61,7 @@ class Renderer implements RendererInterface
     protected $configResolver;
 
     /**
-     * @var \Symfony\Component\Templating\EngineInterface
+     * @var \Twig\Environment
      */
     protected $templateEngine;
 
@@ -84,7 +84,7 @@ class Renderer implements RendererInterface
      * @param \eZ\Publish\API\Repository\Repository $repository
      * @param \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface $authorizationChecker
      * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
-     * @param \Symfony\Component\Templating\EngineInterface $templateEngine
+     * @param \Twig\Environment $templateEngine
      * @param string $tagConfigurationNamespace
      * @param string $styleConfigurationNamespace
      * @param string $embedConfigurationNamespace
@@ -96,7 +96,7 @@ class Renderer implements RendererInterface
         Repository $repository,
         AuthorizationCheckerInterface $authorizationChecker,
         ConfigResolverInterface $configResolver,
-        EngineInterface $templateEngine,
+        Environment $templateEngine,
         $tagConfigurationNamespace,
         $styleConfigurationNamespace,
         $embedConfigurationNamespace,
@@ -172,7 +172,7 @@ class Renderer implements RendererInterface
             return null;
         }
 
-        if (!$this->templateEngine->exists($templateName)) {
+        if (!$this->templateEngine->getLoader()->exists($templateName)) {
             $this->logger->error(
                 "Could not render embedded resource: template '{$templateName}' does not exists"
             );
@@ -232,7 +232,7 @@ class Renderer implements RendererInterface
             return null;
         }
 
-        if (!$this->templateEngine->exists($templateName)) {
+        if (!$this->templateEngine->getLoader()->exists($templateName)) {
             $this->logger->error(
                 "Could not render embedded resource: template '{$templateName}' does not exists"
             );
@@ -272,7 +272,7 @@ class Renderer implements RendererInterface
             return null;
         }
 
-        if (!$this->templateEngine->exists($templateName)) {
+        if (!$this->templateEngine->getLoader()->exists($templateName)) {
             $this->logger->error(
                 "Could not render template {$type} '{$name}': template '{$templateName}' does not exist"
             );

--- a/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -106,7 +106,7 @@ class RichTextTest extends AbstractParserTestCase
         $this->assertConfigResolverParameterValue(
             'fieldtypes.ezrichtext.tags.default',
             [
-                'template' => 'EzPlatformRichTextBundle:RichText/tag:default.html.twig',
+                'template' => '@EzPlatformRichText/RichText/tag/default.html.twig',
             ],
             'ezdemo_site'
         );

--- a/tests/bundle/eZ/RichText/RendererTest.php
+++ b/tests/bundle/eZ/RichText/RendererTest.php
@@ -21,7 +21,8 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Exception;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Templating\EngineInterface;
+use Twig\Environment;
+use Twig\Loader\LoaderInterface;
 
 class RendererTest extends TestCase
 {
@@ -32,6 +33,7 @@ class RendererTest extends TestCase
         $this->configResolverMock = $this->getConfigResolverMock();
         $this->templateEngineMock = $this->getTemplateEngineMock();
         $this->loggerMock = $this->getLoggerMock();
+        $this->loaderMock = $this->getLoaderMock();
         parent::setUp();
     }
 
@@ -56,11 +58,15 @@ class RendererTest extends TestCase
             ->with($name, $isInline)
             ->willReturn($templateName);
 
-        $this->templateEngineMock
-            ->expects($this->once())
+        $this->loaderMock
             ->method('exists')
             ->with($templateName)
             ->willReturn(true);
+
+        $this->templateEngineMock
+            ->expects($this->once())
+            ->method('getLoader')
+            ->willReturn($this->loaderMock);
 
         $this->loggerMock
             ->expects($this->never())
@@ -91,7 +97,7 @@ class RendererTest extends TestCase
 
         $this->templateEngineMock
             ->expects($this->never())
-            ->method('exists');
+            ->method('getLoader');
 
         $this->loggerMock
             ->expects($this->once())
@@ -121,11 +127,15 @@ class RendererTest extends TestCase
             ->with($name, $isInline)
             ->willReturn('templateName');
 
-        $this->templateEngineMock
-            ->expects($this->once())
+        $this->loaderMock
             ->method('exists')
             ->with($templateName)
             ->willReturn(false);
+
+        $this->templateEngineMock
+            ->expects($this->once())
+            ->method('getLoader')
+            ->willReturn($this->loaderMock);
 
         $this->loggerMock
             ->expects($this->once())
@@ -261,11 +271,15 @@ class RendererTest extends TestCase
                 ->expects($this->never())
                 ->method($this->anything());
         } else {
-            $this->templateEngineMock
-                ->expects($this->once())
+            $this->loaderMock
                 ->method('exists')
                 ->with($templateEngineTemplate)
                 ->willReturn(true);
+
+            $this->templateEngineMock
+                ->expects($this->once())
+                ->method('getLoader')
+                ->willReturn($this->loaderMock);
         }
 
         if (empty($configResolverParams)) {
@@ -347,11 +361,15 @@ class RendererTest extends TestCase
             ->with(Renderer::RESOURCE_TYPE_CONTENT, $isInline, $isDenied)
             ->willReturn($templateName);
 
-        $this->templateEngineMock
-            ->expects($this->once())
+        $this->loaderMock
             ->method('exists')
             ->with($templateName)
             ->willReturn(true);
+
+        $this->templateEngineMock
+            ->expects($this->once())
+            ->method('getLoader')
+            ->willReturn($this->loaderMock);
 
         $this->loggerMock
             ->expects($this->never())
@@ -399,7 +417,7 @@ class RendererTest extends TestCase
 
         $this->templateEngineMock
             ->expects($this->never())
-            ->method('exists');
+            ->method('getLoader');
 
         $this->loggerMock
             ->expects($this->once())
@@ -444,11 +462,15 @@ class RendererTest extends TestCase
             ->with(Renderer::RESOURCE_TYPE_CONTENT, $isInline, $isDenied)
             ->willReturn($templateName);
 
-        $this->templateEngineMock
-            ->expects($this->once())
+        $this->loaderMock
             ->method('exists')
             ->with($templateName)
             ->willReturn(false);
+
+        $this->templateEngineMock
+            ->expects($this->once())
+            ->method('getLoader')
+            ->willReturn($this->loaderMock);
 
         $this->loggerMock
             ->expects($this->once())
@@ -497,11 +519,15 @@ class RendererTest extends TestCase
             ->with(Renderer::RESOURCE_TYPE_CONTENT, $isInline, $isDenied)
             ->willReturn($templateName);
 
-        $this->templateEngineMock
-            ->expects($this->once())
+        $this->loaderMock
             ->method('exists')
             ->with($templateName)
             ->willReturn(true);
+
+        $this->templateEngineMock
+            ->expects($this->once())
+            ->method('getLoader')
+            ->willReturn($this->loaderMock);
 
         $this->loggerMock
             ->expects($this->once())
@@ -595,7 +621,7 @@ class RendererTest extends TestCase
 
         $this->templateEngineMock
             ->expects($this->never())
-            ->method('exists');
+            ->method('getLoader');
 
         $this->loggerMock
             ->expects($this->once())
@@ -810,11 +836,15 @@ class RendererTest extends TestCase
                 ->expects($this->never())
                 ->method($this->anything());
         } else {
-            $this->templateEngineMock
-                ->expects($this->once())
+            $this->loaderMock
                 ->method('exists')
                 ->with($templateEngineTemplate)
                 ->willReturn(true);
+
+            $this->templateEngineMock
+                ->expects($this->once())
+                ->method('getLoader')
+                ->willReturn($this->loaderMock);
         }
 
         if (empty($configResolverParams)) {
@@ -895,11 +925,15 @@ class RendererTest extends TestCase
             ->with(Renderer::RESOURCE_TYPE_LOCATION, $isInline, $isDenied)
             ->willReturn($templateName);
 
-        $this->templateEngineMock
-            ->expects($this->once())
+        $this->loaderMock
             ->method('exists')
             ->with($templateName)
             ->willReturn(true);
+
+        $this->templateEngineMock
+            ->expects($this->once())
+            ->method('getLoader')
+            ->willReturn($this->loaderMock);
 
         $this->loggerMock
             ->expects($this->never())
@@ -946,7 +980,7 @@ class RendererTest extends TestCase
 
         $this->templateEngineMock
             ->expects($this->never())
-            ->method('exists');
+            ->method('getLoader');
 
         $this->loggerMock
             ->expects($this->once())
@@ -991,11 +1025,15 @@ class RendererTest extends TestCase
             ->with(Renderer::RESOURCE_TYPE_LOCATION, $isInline, $isDenied)
             ->willReturn($templateName);
 
-        $this->templateEngineMock
-            ->expects($this->once())
+        $this->loaderMock
             ->method('exists')
             ->with($templateName)
             ->willReturn(false);
+
+        $this->templateEngineMock
+            ->expects($this->once())
+            ->method('getLoader')
+            ->willReturn($this->loaderMock);
 
         $this->loggerMock
             ->expects($this->once())
@@ -1036,11 +1074,15 @@ class RendererTest extends TestCase
             ->with(Renderer::RESOURCE_TYPE_LOCATION, $isInline, $isDenied)
             ->willReturn($templateName);
 
-        $this->templateEngineMock
-            ->expects($this->once())
+        $this->loaderMock
             ->method('exists')
             ->with($templateName)
             ->willReturn(true);
+
+        $this->templateEngineMock
+            ->expects($this->once())
+            ->method('getLoader')
+            ->willReturn($this->loaderMock);
 
         $this->loggerMock
             ->expects($this->once())
@@ -1084,7 +1126,7 @@ class RendererTest extends TestCase
 
         $this->templateEngineMock
             ->expects($this->never())
-            ->method('exists');
+            ->method('getLoader');
 
         $this->loggerMock
             ->expects($this->once())
@@ -1132,7 +1174,7 @@ class RendererTest extends TestCase
 
         $this->templateEngineMock
             ->expects($this->never())
-            ->method('exists');
+            ->method('getLoader');
 
         $this->loggerMock
             ->expects($this->once())
@@ -1338,11 +1380,15 @@ class RendererTest extends TestCase
                 ->expects($this->never())
                 ->method($this->anything());
         } else {
-            $this->templateEngineMock
-                ->expects($this->once())
+            $this->loaderMock
                 ->method('exists')
                 ->with($templateEngineTemplate)
                 ->willReturn(true);
+
+            $this->templateEngineMock
+                ->expects($this->once())
+                ->method('getLoader')
+                ->willReturn($this->loaderMock);
         }
 
         if (empty($configResolverParams)) {
@@ -1460,7 +1506,7 @@ class RendererTest extends TestCase
      */
     protected function getTemplateEngineMock()
     {
-        return $this->createMock(EngineInterface::class);
+        return $this->createMock(Environment::class);
     }
 
     /**
@@ -1474,6 +1520,19 @@ class RendererTest extends TestCase
     protected function getLoggerMock()
     {
         return $this->createMock(LoggerInterface::class);
+    }
+
+    /**
+     * @var \Twig\Loader\LoaderInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $loaderMock;
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getLoaderMock()
+    {
+        return $this->createMock(LoaderInterface::class);
     }
 
     protected function getContentMock($mainLocationId)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30906](https://jira.ez.no/browse/EZP-30906)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

main PR:
https://github.com/ezsystems/ezplatform/pull/453

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
