### PR TITLE
EZP-30934: Removed usage of deprecated getCurrentUser method

### DIFF
--- a/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
@@ -568,13 +568,14 @@ EOT;
         $contentService = $repository->getContentService();
         $contentTypeService = $repository->getContentTypeService();
         $locationService = $repository->getLocationService();
+        $permissionResolver = $repository->getPermissionResolver();
 
         // Create Type containing RichText Field definition
         $createStruct = $contentTypeService->newContentTypeCreateStruct('test-RichText');
         $createStruct->mainLanguageCode = 'eng-GB';
         $createStruct->remoteId = 'test-RichText-abcdefghjklm9876543210';
         $createStruct->names = ['eng-GB' => 'Test'];
-        $createStruct->creatorId = $repository->getCurrentUser()->id;
+        $createStruct->creatorId = $permissionResolver->getCurrentUserReference()->getUserId();
         $createStruct->creationDate = $this->createDateTime();
 
         $fieldCreate = $contentTypeService->newFieldDefinitionCreateStruct('description', 'ezrichtext');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30934](https://jira.ez.no/browse/EZP-30934)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
