### PR TITLE
EZP-30933: Added "link" Custom Tag attribute type

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -14,7 +14,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class Configuration extends SiteAccessConfiguration
 {
-    const CUSTOM_TAG_ATTRIBUTE_TYPES = ['number', 'string', 'boolean', 'choice'];
+    const CUSTOM_TAG_ATTRIBUTE_TYPES = ['number', 'string', 'boolean', 'choice', 'link'];
 
     /**
      * Generates the configuration tree builder.

--- a/tests/bundle/DependencyInjection/Configuration/ConfigurationTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/ConfigurationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformRichTextBundle\DependencyInjection\Configuration;
+
+use EzSystems\EzPlatformRichTextBundle\DependencyInjection\Configuration;
+use PHPUnit\Framework\TestCase;
+use SplFileInfo;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Yaml;
+
+final class ConfigurationTest extends TestCase
+{
+    private const INPUT_FIXTURES_DIR = __DIR__ . '/../Fixtures/custom_tags/input/';
+    private const OUTPUT_FIXTURES_DIR = __DIR__ . '/../Fixtures/custom_tags/output/';
+
+    /**
+     * @dataProvider providerForTestProcessingConfiguration
+     */
+    public function testProcessingConfiguration(SplFileInfo $inputConfigurationFile): void
+    {
+        $outputFilePath = self::OUTPUT_FIXTURES_DIR . $inputConfigurationFile->getFilename();
+        if (!file_exists($outputFilePath)) {
+            $this->markTestIncomplete("Missing output fixture: {$outputFilePath}");
+        }
+
+        $configs = [Yaml::parseFile($inputConfigurationFile->getPathname())];
+        $expectedProcessedConfiguration = Yaml::parseFile($outputFilePath);
+
+        $configuration = new Configuration();
+        $processor = new Processor();
+        $processedConfiguration = $processor->processConfiguration($configuration, $configs);
+
+        self::assertEquals(
+            $expectedProcessedConfiguration,
+            $processedConfiguration
+        );
+    }
+
+    public function providerForTestProcessingConfiguration(): iterable
+    {
+        $finder = new Finder();
+        $finder
+            ->files()
+            ->in(self::INPUT_FIXTURES_DIR)
+            ->name('*.yaml')
+            ->sortByName()
+        ;
+
+        foreach ($finder as $file) {
+            yield [$file];
+        }
+    }
+}

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/000-attribute-type-number.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/000-attribute-type-number.yaml
@@ -1,0 +1,9 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'number'
+                required: true
+                default_value: 360

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/001-attribute-type-string.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/001-attribute-type-string.yaml
@@ -1,0 +1,9 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'string'
+                required: true
+                default_value: 'abc'

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/002-attribute-type-boolean.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/002-attribute-type-boolean.yaml
@@ -1,0 +1,7 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'boolean'

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/003-attribute-type-choice.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/003-attribute-type-choice.yaml
@@ -1,0 +1,10 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'choice'
+                required: true
+                default_value: 'choice-1'
+                choices: ['choice-1', 'choice-2']

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/004-attribute-type-link.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/input/004-attribute-type-link.yaml
@@ -1,0 +1,8 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'link'
+                required: true

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/000-attribute-type-number.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/000-attribute-type-number.yaml
@@ -1,0 +1,11 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'number'
+                required: true
+                default_value: 360
+        is_inline: false
+custom_styles: []

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/001-attribute-type-string.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/001-attribute-type-string.yaml
@@ -1,0 +1,11 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'string'
+                required: true
+                default_value: 'abc'
+        is_inline: false
+custom_styles: []

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/002-attribute-type-boolean.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/002-attribute-type-boolean.yaml
@@ -1,0 +1,11 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'boolean'
+                required: false
+                default_value: ~
+        is_inline: false
+custom_styles: []

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/003-attribute-type-choice.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/003-attribute-type-choice.yaml
@@ -1,0 +1,12 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'choice'
+                required: true
+                default_value: 'choice-1'
+                choices: ['choice-1', 'choice-2']
+        is_inline: false
+custom_styles: []

--- a/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/004-attribute-type-link.yaml
+++ b/tests/bundle/DependencyInjection/Fixtures/custom_tags/output/004-attribute-type-link.yaml
@@ -1,0 +1,11 @@
+custom_tags:
+    foo:
+        template: 'MyBundle:FieldType/RichText/tag:foo.html.twig'
+        icon: '/bundles/mybundle/fieldtype/richtext/foo.svg#foo'
+        attributes:
+            bar:
+                type: 'link'
+                required: true
+                default_value: ~
+        is_inline: false
+custom_styles: []


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30933](https://jira.ez.no/browse/EZP-30933)
| **Requires** | ezsystems/ezplatform-admin-ui#1112
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.1` for eZ Platform `v2.5.x` LTS
| **BC breaks**      | no
| **Tests pass**     | [yes](https://travis-ci.org/ezsystems/ezplatform-richtext/builds/602236414)
| **Doc needed**     | yes

**Note: _Inability to migrate from `ezxmltext` to `ezrichtext` due to input field validation error is considered here as a bug, nothing more._**

This PR provides a minimal support for the Custom Tag `link` attribute type. That attribute type can be configured in the following way:
``` yaml
ezrichtext:
    custom_tags:
        <tag_name>:
                # other settings
                link:
                    type: link
                    required: true
```

For the full working example please see [ezp-30933-custom-tag-link-attribute-for-qa](https://github.com/ezsystems/ezplatform/compare/2.5...alongosz:ezp-30933-custom-tag-link-attribute-for-qa).

The attribute value provided as-is in the DocBook XML of a content item is propagated to OE. By means of ezsystems/ezplatform-admin-ui#1112 OE can display a text input field with an ability to enable editing of that attribute as-is. Full support of setting that link in OE is out of scope here and will require UI design and much more work (I tried).

### Differences from eZ Publish Platform (5.4)

`LinkType` configuration has been dropped for now. Value was stored as-is anyway. It depends a lot of the UI, which is now missing. It might be even not needed (TBD).

### Roads not taken

After a deep investigation, the fix has been provided as a simple addition to hard-coded list of supported attribute types.

Other additional possibilities (not alternatives) checked:

1. UI for choosing a Location from UDW (investigated in ezsystems/ezplatform-admin-ui#1112, as said above, too complicated).
2. Making list of custom tag attributes extendable (much more complicated as well, might require changes to configuration format).

### Known issues

External links in the new stack are handled by `ezurl://` and are visible in the Link Manager in AdminUI. Since value here is provided as-is, this is not supported yet for link Custom Tag attributes, nor should be in the scope of the change. We could refactor that in the future and provide migration.

### QA

- [ ] Create a custom tag with `link` attribute type. Example: [ezp-30933-custom-tag-link-attribute-for-qa](https://github.com/ezsystems/ezplatform/compare/2.5...alongosz:ezp-30933-custom-tag-link-attribute-for-qa).
- [ ] Test migration // steps are described internally in one of the comments in the JIRA issue. The mentioned branch for QA already has in place configuration described there.

**TODO**:
- [ ] Merge up: `composer require --dev symfony/finder`
- [x] Add "link" Custom Tag attribute type
- [x] Added test coverage for Custom Tag "link" attribute type
- [x] Implemented tests for processing of Custom Templates config
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Provide QA with instruction to test migration from `ezxmltext` to `ezrichtext`.
- [x] Remove TMP commit after CI passes.
- [x] Ask for Code Review.
