### PR TITLE
EZP-31076: Marking embed content as hidden doesn't change its visibility

### DIFF
--- a/src/bundle/eZ/RichText/Renderer.php
+++ b/src/bundle/eZ/RichText/Renderer.php
@@ -155,6 +155,14 @@ class Renderer implements RendererInterface
                 return null;
             }
 
+            if ($content->contentInfo->isHidden) {
+                $this->logger->error(
+                    "Could not render embedded resource: Content #{$contentId} is hidden."
+                );
+
+                return null;
+            }
+
             $this->checkContentPermissions($content);
         } catch (AccessDeniedException $e) {
             $this->logger->error(

--- a/tests/bundle/eZ/RichText/RendererTest.php
+++ b/tests/bundle/eZ/RichText/RendererTest.php
@@ -551,6 +551,47 @@ class RendererTest extends TestCase
         );
     }
 
+    public function testRenderContentEmbedHidden()
+    {
+        $renderer = $this->getMockedRenderer(['checkContentPermissions']);
+        $contentId = 42;
+        $viewType = 'embedTest';
+        $parameters = ['parameters'];
+        $isInline = true;
+
+        $contentInfoMock = $this->createMock(ContentInfo::class);
+        $contentInfoMock
+            ->expects($this->at(0))
+            ->method('__get')
+            ->with('mainLocationId')
+            ->willReturn(2);
+        $contentInfoMock
+            ->expects($this->at(1))
+            ->method('__get')
+            ->with('isHidden')
+            ->willReturn(true);
+
+        $contentMock = $this->createMock(Content::class);
+        $contentMock
+            ->method('__get')
+            ->with('contentInfo')
+            ->willReturn($contentInfoMock);
+
+        $this->repositoryMock
+            ->expects($this->once())
+            ->method('sudo')
+            ->willReturn($contentMock);
+
+        $this->loggerMock
+            ->expects($this->once())
+            ->method('error')
+            ->with("Could not render embedded resource: Content #{$contentId} is hidden.");
+
+        $this->assertNull(
+            $renderer->renderContentEmbed($contentId, $viewType, $parameters, $isInline)
+        );
+    }
+
     public function providerForTestRenderContentEmbedNotFound()
     {
         return [
@@ -1480,14 +1521,18 @@ class RendererTest extends TestCase
     {
         $contentInfoMock = $this->createMock(ContentInfo::class);
         $contentInfoMock
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('__get')
             ->with('mainLocationId')
             ->willReturn($mainLocationId);
+        $contentInfoMock
+            ->expects($this->at(1))
+            ->method('__get')
+            ->with('isHidden')
+            ->willReturn(false);
 
         $contentMock = $this->createMock(Content::class);
         $contentMock
-            ->expects($this->once())
             ->method('__get')
             ->with('contentInfo')
             ->willReturn($contentInfoMock);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31076](https://jira.ez.no/browse/EZP-31076)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `1.1`/`master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

As mentioned in the JIRA ticket, currently embedded content is displayed even if it's hidden. This PR fixes this incorrect behavior. 


**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
