### PR TITLE
EZP-31087: Fixed merging Online Editor extra_buttons semantic config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
+        "matthiasnoback/symfony-config-test": "^4.1",
         "matthiasnoback/symfony-dependency-injection-test": "~3.0",
         "friendsofphp/php-cs-fixer": "^2.16",
         "ezsystems/ezplatform-code-style": "^0.1"

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -193,6 +193,7 @@ class Configuration extends SiteAccessConfiguration
                             ->prototype('scalar')->end()
                         ->end()
                         ->arrayNode('extra_buttons')
+                            ->useAttributeAsKey('name')
                             ->arrayPrototype()
                                 ->example(['button1', 'button2'])
                                 ->prototype('scalar')->end()


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31087](https://jira.ez.no/browse/EZP-31087)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**Steps to reproduce**
1. Install/enable the first bundle, which provides an additional button in Online Editor, f.e. [ezplatform-content-variables](https://ezplatform.com/packages/contextualcode-ezplatform-content-variables). And check that the "Content Variables" button is injected into the OE.
2. Install/enabled the second bundle, which also provides an additional button in Online Editor, f.e. [ezplatform-alloyeditor-source](https://ezplatform.com/packages/contextualcode-ezplatform-alloyeditor-source). And check that the "Edit Source" button is injected into the OE.

**Expected results**
Both buttons ("Content Variables" and "Edit Source") are injected into the Online Editor.

**Actual results**
There is only the "Edit Source" button in the Online Editor. So if there are multiple bundles with custom online editor buttons, there will be shown only the ones from the bundle which was enabled last.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
