### PR TITLE
EZP-31108: [CS] Enabled ezsystems/ezplatform-code-style package

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,9 +1,25 @@
 <?php
 
-return EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build()
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+$config = EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build();
+$config
+    ->setRules(
+        array_merge(
+            $config->getRules(),
+            [
+                'declare_strict_types' => true,
+            ]
+        )
+    )
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in([__DIR__ . '/src', __DIR__ . '/tests'])
             ->files()->name('*.php')
-    )
-;
+    );
+
+return $config;

--- a/.php_cs
+++ b/.php_cs
@@ -1,36 +1,6 @@
 <?php
 
-$header = <<<'EOF'
-@copyright Copyright (C) eZ Systems AS. All rights reserved.
-@license For full copyright and license information view LICENSE file distributed with this source code.
-EOF;
-
-return PhpCsFixer\Config::create()
-    ->setRules([
-        '@Symfony' => true,
-        '@Symfony:risky' => true,
-        'concat_space' => ['spacing' => 'one'],
-        'array_syntax' => ['syntax' => 'short'],
-        'simplified_null_return' => false,
-        'phpdoc_align' => false,
-        'phpdoc_to_comment' => false,
-        'cast_spaces' => false,
-        'blank_line_after_opening_tag' => false,
-        'single_blank_line_before_namespace' => true,
-        'space_after_semicolon' => false,
-        'header_comment' => [
-            'commentType' => 'PHPDoc',
-            'header' => $header,
-            'location' => 'after_open',
-            'separate' => 'top',
-        ],
-        'yoda_style' => false,
-        'no_break_comment' => false,
-        'declare_strict_types' => true,
-        'native_function_invocation' => false,
-        'phpdoc_types_order' => false,
-    ])
-    ->setRiskyAllowed(true)
+return EzSystems\EzPlatformCodeStyle\PhpCsFixer\EzPlatformInternalConfigFactory::build()
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in([__DIR__ . '/src', __DIR__ . '/tests'])

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "matthiasnoback/symfony-dependency-injection-test": "~3.0",
-        "friendsofphp/php-cs-fixer": "~2.15.0"
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "ezsystems/ezplatform-code-style": "^0.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/bundle/eZ/RichText/Renderer.php
+++ b/src/bundle/eZ/RichText/Renderer.php
@@ -66,7 +66,7 @@ class Renderer implements RendererInterface
     protected $templateEngine;
 
     /**
-     * @var null|\Psr\Log\LoggerInterface
+     * @var \Psr\Log\LoggerInterface|null
      */
     protected $logger;
 
@@ -88,7 +88,7 @@ class Renderer implements RendererInterface
      * @param string $tagConfigurationNamespace
      * @param string $styleConfigurationNamespace
      * @param string $embedConfigurationNamespace
-     * @param null|\Psr\Log\LoggerInterface $logger
+     * @param \Psr\Log\LoggerInterface|null $logger
      * @param array $customTagsConfiguration
      * @param array $customStylesConfiguration
      */
@@ -329,7 +329,7 @@ class Renderer implements RendererInterface
      * @param string $identifier
      * @param bool $isInline
      *
-     * @return null|string
+     * @return string|null
      */
     protected function getStyleTemplateName($identifier, $isInline)
     {
@@ -366,7 +366,7 @@ class Renderer implements RendererInterface
      * @param string $identifier
      * @param bool $isInline
      *
-     * @return null|string
+     * @return string|null
      */
     protected function getTagTemplateName($identifier, $isInline)
     {
@@ -414,7 +414,7 @@ class Renderer implements RendererInterface
      * @param $isInline
      * @param $isDenied
      *
-     * @return null|string
+     * @return string|null
      */
     protected function getEmbedTemplateName($resourceType, $isInline, $isDenied)
     {

--- a/src/lib/eZ/RichText/Converter/Render/Embed.php
+++ b/src/lib/eZ/RichText/Converter/Render/Embed.php
@@ -23,7 +23,7 @@ use DOMElement;
 class Embed extends Render implements Converter
 {
     /**
-     * @var null|\Psr\Log\LoggerInterface
+     * @var \Psr\Log\LoggerInterface|null
      */
     protected $logger;
 

--- a/src/lib/eZ/RichText/ConverterDispatcher.php
+++ b/src/lib/eZ/RichText/ConverterDispatcher.php
@@ -37,7 +37,7 @@ class ConverterDispatcher
      * Adds converter mapping.
      *
      * @param string $namespace
-     * @param null|\EzSystems\EzPlatformRichText\eZ\RichText\Converter $converter
+     * @param \EzSystems\EzPlatformRichText\eZ\RichText\Converter|null $converter
      */
     public function addConverter($namespace, Converter $converter = null)
     {

--- a/src/lib/eZ/RichText/XmlBase.php
+++ b/src/lib/eZ/RichText/XmlBase.php
@@ -21,7 +21,7 @@ abstract class XmlBase
      * When recording errors holds previous setting for libxml user error handling,
      * null otherwise.
      *
-     * @var null|bool
+     * @var bool|null
      */
     protected $useInternalErrors;
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31108](https://jira.ez.no/browse/EZP-31108)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `v1.1.x` and up (of this package)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR enables the [ezsystems/ezplatform-code-style](https://github.com/ezsystems/ezplatform-code-style) package, in order to use common rules defined via ezsystems/ezplatform-code-style#3.

**TODO**:
- [x] Bump php-cs-fixer version to `^2.16` to align with  ezsystems/ezplatform-code-style#3
- [x] Use eZ Platform internal factory to build PHP-CS-Fixer configuration.
- [x] Resolve outstanding CS issues (`phpdoc_types_order`).
- [x] Re-enable `declare_strict_types` PHP-CS-Fixer rule.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for code review.
