### PR TITLE
EZP-31130: Ensured content variable is always present in Custom Template Twig view

### DIFF
--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -107,9 +107,7 @@ class Template extends Render implements Converter
         foreach ($contentNodes as $contentNode) {
             $innerContent .= $this->getCustomTemplateContent($contentNode);
         }
-        if (!empty($innerContent)) {
-            $parameters['content'] = $innerContent;
-        }
+        $parameters['content'] = !empty($innerContent) ? $innerContent : null;
 
         if ($template->hasAttribute('ezxhtml:align')) {
             $parameters['align'] = $template->getAttribute('ezxhtml:align');

--- a/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
@@ -8,11 +8,11 @@ declare(strict_types=1);
 
 namespace EzSystems\Tests\EzPlatformRichText\eZ\RichText\Converter\Render;
 
-use PHPUnit\Framework\TestCase;
+use DOMDocument;
 use EzSystems\EzPlatformRichText\eZ\RichText\Converter;
 use EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render\Template;
 use EzSystems\EzPlatformRichText\eZ\RichText\RendererInterface;
-use DOMDocument;
+use PHPUnit\Framework\TestCase;
 
 class TemplateTest extends TestCase
 {
@@ -75,10 +75,6 @@ class TemplateTest extends TestCase
 
     /**
      * @dataProvider providerForTestConvert
-     *
-     * @param \DOMDocument $inputDocument
-     * @param \DOMDocument $expectedOutputDocument
-     * @param array $expectedRenderParams
      */
     public function testConvert(DOMDocument $inputDocument, DOMDocument $expectedOutputDocument, array $expectedRenderParams)
     {
@@ -108,6 +104,8 @@ class TemplateTest extends TestCase
                         ->method('convert')
                         ->with($contentDoc)
                         ->willReturn($contentDoc);
+                } else {
+                    $params['params']['content'] = null;
                 }
 
                 $this->rendererMock
@@ -164,6 +162,7 @@ class TemplateTest extends TestCase
                     'params' => [
                     ],
                 ],
+                'content' => null,
             ],
         ],
         '01-complex-config' => [
@@ -188,6 +187,7 @@ class TemplateTest extends TestCase
                         ],
                     ],
                 ],
+                'content' => null,
             ],
         ],
         '02-block-inline' => [
@@ -199,6 +199,7 @@ class TemplateTest extends TestCase
                     'params' => [
                     ],
                 ],
+                'content' => null,
             ],
             [
                 'name' => 'template4',
@@ -208,6 +209,7 @@ class TemplateTest extends TestCase
                     'params' => [
                     ],
                 ],
+                'content' => null,
             ],
         ],
         '03-inline' => [
@@ -219,6 +221,7 @@ class TemplateTest extends TestCase
                     'params' => [
                     ],
                 ],
+                'content' => null,
             ],
         ],
         '04-block-nested-template' => [
@@ -231,6 +234,7 @@ class TemplateTest extends TestCase
                     'params' => [
                     ],
                 ],
+                'content' => null,
             ],
             [
                 'name' => 'template8',
@@ -241,6 +245,7 @@ class TemplateTest extends TestCase
                     'params' => [
                     ],
                 ],
+                'content' => null,
             ],
         ],
         '05-block-content-config' => [
@@ -255,6 +260,7 @@ class TemplateTest extends TestCase
                     ],
                     'align' => 'right',
                 ],
+                'content' => null,
             ],
         ],
         '06-custom-style-block' => [
@@ -268,6 +274,7 @@ class TemplateTest extends TestCase
                     'params' => [
                     ],
                 ],
+                'content' => null,
             ],
         ],
         '07-custom-style-block-inline' => [
@@ -281,6 +288,7 @@ class TemplateTest extends TestCase
                     'params' => [
                     ],
                 ],
+                'content' => null,
             ],
             [
                 'name' => 'style3',
@@ -292,6 +300,7 @@ class TemplateTest extends TestCase
                     'params' => [
                     ],
                 ],
+                'content' => null,
             ],
         ],
         '08-line-breaks' => [
@@ -304,6 +313,7 @@ class TemplateTest extends TestCase
                     'content' => "<literallayout>Some content\nwith line breaks.</literallayout>",
                     'params' => [],
                 ],
+                'content' => null,
             ],
         ],
     ];

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/024-template.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/024-template.xml
@@ -40,6 +40,7 @@
       <param name="alt">flip-flop</param>
       <param name="caption">bistable multivibrator</param>
     </param>
+    <param name="content"/>
     <param name="align">right</param>
   </template-output>
   <template-output is-inline="false" name="factoidbox" type="tag">
@@ -51,6 +52,7 @@
   </template-output>
   <template-output is-inline="false" name="factoidbox" type="tag">
     <param name="name">factoidbox</param>
+    <param name="content"/>
     <param name="align">center</param>
   </template-output>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/025-templateInline.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/025-templateInline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <p>Some <template-output is-inline="true" name="emojicake" type="tag"><param name="name">emojicake</param></template-output> for the otherwise unremarkable paragraph.</p>
-  <p>This paragraph is just showing off its <template-output is-inline="true" name="emojicrocodile" type="tag"><param name="name">emojicrocodile</param><param name="params"><param name="size">large</param></param></template-output>.</p>
+  <p>Some <template-output is-inline="true" name="emojicake" type="tag"><param name="name">emojicake</param><param name="content"/></template-output> for the otherwise unremarkable paragraph.</p>
+  <p>This paragraph is just showing off its <template-output is-inline="true" name="emojicrocodile" type="tag"><param name="name">emojicrocodile</param><param name="params"><param name="size">large</param></param><param name="content"/></template-output>.</p>
   <p>The equation <template-output is-inline="true" name="tex" type="tag"><param name="name">tex</param><param name="params"><param name="color">red</param></param><param name="content"><section>e^{\pi i}+1=0</section></param></template-output> ties together five of the most important mathematical constants.</p>
   <p>This paragraph contains some <template-output is-inline="true" name="bold" type="tag"><param name="name">bold</param><param name="content"><section>styled <template-output is-inline="true" name="strikedthrough" type="tag"><param name="name">strikedthrough</param><param name="content"><section>text</section></param></template-output></section></param></template-output>.</p>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/034-nestedTemplate.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/034-nestedTemplate.xml
@@ -18,6 +18,7 @@
             <param name="alt">flip-flop</param>
             <param name="caption">bistable multivibrator</param>
           </param>
+          <param name="content"/>
           <param name="align">right</param>
         </template-output>
       </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31130](https://jira.ez.no/browse/EZP-31130)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `v1.1.x` for eZ Platform `2.5.x` LTS
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no, doc is already aligned

This PR introduces small change - ensuring that `content` Twig variable is always present in Custom Template (Tag, Style) Twig view.

eZ Platform DocBook schema (`.rng`) currently allows `ezcontent` tag to be not present in `eztemplate`. While AdminUI ensures `ezcontent` is always set, even if empty, a DocBook comming from migrated `XmlText` might not have this tag sometimes. This resulted in `content` Twig variable being not present in a Twig view for a given Custom Template, which yields a fatal error both on a front site and in AdminUI Location View.

There were 3 directions to solve that issue:
1. Force a developer to check for existence of that variable.
2. Add `ezcontent` tag during migration from XmlText to RichText.
3. Make `content` variable always present in a Twig view for Custom Template.

The second option was rejected because RNG schema defines `ezcontent` as optional.
The first option yields bad DX.

Currently this PR implements the third option, so a developer, instead of writing:
``` twig
{% if content is defined %}{{ content|raw }}{% endif %}
```
can simply write:
``` twig
{{ content|raw }}
```
which is also [consistent with the doc that we provide](https://doc.ezplatform.com/en/2.5/guide/extending/extending_online_editor/#rendering).

### QA

- [ ] Sanity checks for creating Custom Tags with or without content.
- [ ] Test: Create a Custom Tag, find it in `ezcontentobject_attributes`, remove `<content>...</content>` markup from XML, save, clear cache, observe the mentioned error on a front site.

**TODO**:
- [x] Always expose `content` variable in Twig views for Custom Templates.
- [x] Align tests.
- [ ] Rebase after merging #83
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
