### PR TITLE
EZP-31118: Introduced strict types for ContenteService

### DIFF
--- a/src/bundle/eZ/RichText/Renderer.php
+++ b/src/bundle/eZ/RichText/Renderer.php
@@ -127,7 +127,7 @@ class Renderer implements RendererInterface
             /** @var \eZ\Publish\API\Repository\Values\Content\Content $content */
             $content = $this->repository->sudo(
                 function (Repository $repository) use ($contentId) {
-                    return $repository->getContentService()->loadContent($contentId);
+                    return $repository->getContentService()->loadContent((int)$contentId);
                 }
             );
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31118](https://jira.ez.no/browse/EZP-31118)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |  `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

Fixed issues reported in ezsystems/ezpublish-kernel#2866 (review):

```
Argument 1 passed to eZ\Publish\Core\Repository\ContentService::loadContent() must be of the type int, string given, called in /home/vagrant/master/vendor/ezsystems/ezplatform-richtext/src/bundle/eZ/RichText/Renderer.php on line 130
```


**TODO**:
- [X] Implement feature / fix a bug.
- [ ] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
