### PR TITLE
EZP-31321: Replaced zero-width space with oe-upcast-placeholder

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -585,7 +585,7 @@
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
       <xsl:if test="./docbook:ezattribute or not(node())">
-        <xsl:text> </xsl:text>
+        <xsl:text>ao-upcast-placeholder</xsl:text>
       </xsl:if>
     </xsl:element>
   </xsl:template>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -585,7 +585,7 @@
       <xsl:call-template name="ezattribute"/>
       <xsl:apply-templates/>
       <xsl:if test="./docbook:ezattribute or not(node())">
-        <xsl:text>ao-upcast-placeholder</xsl:text>
+        <xsl:text>oe-upcast-placeholder</xsl:text>
       </xsl:if>
     </xsl:element>
   </xsl:template>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/023-embedInline.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/023-embedInline.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <p>Some <span data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">ao-upcast-placeholder</span> for the otherwise unremarkable paragraph.</p>
+  <p>Some <span data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">oe-upcast-placeholder</span> for the otherwise unremarkable paragraph.</p>
   <p>This paragraph is just showing off its <span data-ezelement="ezembedinline" id="id5" data-href="ezcontent://501" data-ezview="embed-inline" class="embedClass2" data-ezalign="right">
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>
     </span>
   </span> content.</p>
-  <p>Some<span data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembedinline" id="id4" data-href="ezcontent://601">ao-upcast-placeholder</span> content.</p>
+  <p>Some<span data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembedinline" id="id4" data-href="ezcontent://601">oe-upcast-placeholder</span> content.</p>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/023-embedInline.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/023-embedInline.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <p>Some <span data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left"> </span> for the otherwise unremarkable paragraph.</p>
+  <p>Some <span data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">ao-upcast-placeholder</span> for the otherwise unremarkable paragraph.</p>
   <p>This paragraph is just showing off its <span data-ezelement="ezembedinline" id="id5" data-href="ezcontent://501" data-ezview="embed-inline" class="embedClass2" data-ezalign="right">
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>
     </span>
   </span> content.</p>
-  <p>Some<span data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembedinline" id="id4" data-href="ezcontent://601"> </span> content.</p>
+  <p>Some<span data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembedinline" id="id4" data-href="ezcontent://601">ao-upcast-placeholder</span> content.</p>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/035-itemizedListWithNestedElements.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/035-itemizedListWithNestedElements.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
   <ul>
-    <li>This is a list item <span data-ezelement="ezembedinline" data-href="ezcontent://52" data-ezview="embed-inline">ao-upcast-placeholder</span></li>
+    <li>This is a list item <span data-ezelement="ezembedinline" data-href="ezcontent://52" data-ezview="embed-inline">oe-upcast-placeholder</span></li>
   </ul>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/035-itemizedListWithNestedElements.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/035-itemizedListWithNestedElements.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
   <ul>
-    <li>This is a list item <span data-ezelement="ezembedinline" data-href="ezcontent://52" data-ezview="embed-inline"> </span></li>
+    <li>This is a list item <span data-ezelement="ezembedinline" data-href="ezcontent://52" data-ezview="embed-inline">ao-upcast-placeholder</span></li>
   </ul>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31321](https://jira.ez.no/browse/EZP-31321), related to [EZP-29882](https://jira.ez.no/browse/EZP-29882)
| **Required by** | ezsystems/ezplatform-admin-ui#1151
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The original fix for this issue was https://github.com/ezsystems/ezplatform-admin-ui/pull/746. Which fixed the symptoms, but introduced zero-width spaces. Which are causing serious issues in 
https://github.com/ezsystems/ezplatform-admin-ui/pull/1034, and seems to be a nice reason for some very strange bugs in the future.

Before posting this PR, we checked the original issue to understand the reasons why it was happening. So the case is:
1. The user creates new content with a rich text field. That field contains just an inline embed.
2. The content is published and rendered fine.
3. But when the same content is edited - inline embed is not picked by the online editor.

It happens because, in this case, the HTML which is passed to OE contains just a paragraph and child's `span` element, without any child content. And OE skips such kind elements during widgets upcasting. Adding a zero-width space makes that paragraph a non-empty element so its child's `span` is checked for widgets upcasting. But zero-width space adds additional complexity and might cause more serious issues/bugs. That's why our solution seems to be more simple and predicted. It just adds "ao-upcast-placeholder" placeholder in the described scenario. So `span` element for inline embed is not ignored if its parent has no and text nodes, and it is upcasted.

Related PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/1151

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.