### PR TITLE
EZP-30129: Handled bold & italic styles when converting from OE format to DocBook

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -140,7 +140,7 @@
     </blockquote>
   </xsl:template>
 
-  <xsl:template match="ezxhtml5:em">
+  <xsl:template match="ezxhtml5:em | ezxhtml5:i">
     <emphasis>
       <xsl:if test="@class">
         <xsl:attribute name="ezxhtml:class">
@@ -154,7 +154,7 @@
     </emphasis>
   </xsl:template>
 
-  <xsl:template match="ezxhtml5:strong">
+  <xsl:template match="ezxhtml5:strong | ezxhtml5:b">
     <emphasis>
       <xsl:attribute name="role">strong</xsl:attribute>
       <xsl:if test="@class">
@@ -745,6 +745,24 @@
     <xsl:param name="style"/>
     <xsl:param name="property"/>
     <xsl:value-of select="translate( substring-before( substring-after( concat( substring-after( $style, $property ), ';' ), ':' ), ';' ), ' ', '' )"/>
+  </xsl:template>
+
+  <!-- Some fallbacks to handle translating inline formatting in span tags for copy&paste and import use cases -->
+  <xsl:template match="ezxhtml5:span[not(@data-ezelement) and contains(@style,'bold')]">
+    <emphasis>
+      <xsl:attribute name="role">strong</xsl:attribute>
+      <xsl:call-template name="breakline">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
+    </emphasis>
+  </xsl:template>
+
+  <xsl:template match="ezxhtml5:span[not(@data-ezelement) and contains(@style,'italic')]">
+    <emphasis>
+      <xsl:call-template name="breakline">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
+    </emphasis>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/003-inlinestyles.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/003-inlinestyles.docbook.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+    <para>Some <emphasis role="strong">strong</emphasis> content.</para>
+    <para>Some <emphasis role="strong">strong</emphasis> content.</para>
+    <para>Some <emphasis>em</emphasis> content.</para>
+    <para>Some <emphasis>em</emphasis> content.</para>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/003-inlinestyles.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/003-inlinestyles.xhtml5.edit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+  <p>Some <b>strong</b> content.</p>
+  <p>Some <span style="font-weight: bold">strong</span> content.</p>
+  <p>Some <i>em</i> content.</p>
+  <p>Some <span style="font-weight: bold; font-style: italic;">em</span> content.</p>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30129](https://jira.ez.no/browse/EZP-30129)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1 (2.5)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Format coming from copy /paste will often use `<b>` and `<i>` tags, or sometimes also span tags with bold / italic style attribute. This change makes sure to map these cases to the correct docbook tags we support. Solving the linked Word copy / paste issue, as well as improving the code for import use cases from other systems.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
