### PR TITLE
Ported fix for EZP-29958 and EZP-29984 from kernel

### DIFF
--- a/src/lib/eZ/FieldType/RichText/SearchField.php
+++ b/src/lib/eZ/FieldType/RichText/SearchField.php
@@ -78,7 +78,7 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public static function extractShortText(DOMDocument $document)
+    public static function extractShortText(DOMDocument $document): string
     {
         $result = null;
         // try to extract first paragraph/tag

--- a/src/lib/eZ/FieldType/RichText/SearchField.php
+++ b/src/lib/eZ/FieldType/RichText/SearchField.php
@@ -36,7 +36,7 @@ class SearchField implements Indexable
         return [
             new Search\Field(
                 'value',
-                $this->extractShortText($document),
+                self::extractShortText($document),
                 new Search\FieldType\StringField()
             ),
             new Search\Field(
@@ -72,13 +72,16 @@ class SearchField implements Indexable
     /**
      * Extracts short text content of the given $document.
      *
+     * @internal Only for use by RichText FieldType itself.
+     *
      * @param \DOMDocument $document
      *
      * @return string
      */
-    private function extractShortText(DOMDocument $document)
+    public static function extractShortText(DOMDocument $document)
     {
         $result = null;
+        // try to extract first paragraph/tag
         if ($section = $document->documentElement->firstChild) {
             $textDom = $section->firstChild;
 
@@ -93,7 +96,10 @@ class SearchField implements Indexable
             $result = $document->documentElement->textContent;
         }
 
-        return trim($result);
+        // In case of newlines, extract first line. Also limit size to 255 which is maxsize on sql impl.
+        $lines = preg_split('/\r\n|\n|\r/', trim($result), -1, PREG_SPLIT_NO_EMPTY);
+
+        return empty($lines) ? '' : trim(mb_substr($lines[0], 0, 255));
     }
 
     /**

--- a/src/lib/eZ/FieldType/RichText/Type.php
+++ b/src/lib/eZ/FieldType/RichText/Type.php
@@ -164,17 +164,17 @@ class Type extends FieldType
     }
 
     /**
-     * Returns sortKey information.
+     * Returns information for FieldValue->$sortKey relevant to the field type.
      *
      * @see \eZ\Publish\Core\FieldType
      *
      * @param \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\Value $value
      *
-     * @return array|bool
+     * @return string|null
      */
     protected function getSortInfo(BaseValue $value)
     {
-        return false;
+        return SearchField::extractShortText($value->xml);
     }
 
     /**

--- a/src/lib/eZ/Persistence/Legacy/RichTextFieldValueConverter.php
+++ b/src/lib/eZ/Persistence/Legacy/RichTextFieldValueConverter.php
@@ -40,6 +40,7 @@ class RichTextFieldValueConverter implements Converter
     public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
     {
         $storageFieldValue->dataText = $value->data;
+        $storageFieldValue->sortKeyString = $value->sortKey;
     }
 
     /**
@@ -51,6 +52,7 @@ class RichTextFieldValueConverter implements Converter
     public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue)
     {
         $fieldValue->data = $value->dataText ?: Value::EMPTY_VALUE;
+        $fieldValue->sortKey = $value->sortKeyString;
     }
 
     /**
@@ -86,6 +88,6 @@ class RichTextFieldValueConverter implements Converter
      */
     public function getIndexColumn()
     {
-        return false;
+        return 'sort_key_string';
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29984](https://jira.ez.no/browse/EZP-29984) & [EZP-29958](https://jira.ez.no/browse/EZP-29958)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1+
| **BC breaks**      | no
| **Tests pass**     | yes?
| **Doc needed**     | no?

Ports over fixes from:
- EZP-29984: Fix LIKE support for * as wildcard across engines, deprecate % usage
- https://github.com/ezsystems/ezpublish-kernel/pull/2517

Which also happens to align RichText with how XmlText had been fixed for:
- "Creating paragraph longer than 32766 bytes in RichText Editor will fail with Solr Error"
- https://jira.ez.no/browse/EZP-29958


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
