### PR TITLE
EZP-31245: Editing link in paragraph containing more lines ends up with JS error

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-image-link.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-image-link.js
@@ -24,6 +24,11 @@ export default class EzEmbedImageLinkConfig extends EzConfigBase {
      */
     test(payload) {
         const nativeEvent = payload.data.nativeEvent;
+
+        if (!nativeEvent) {
+            return false;
+        }
+
         const target = new CKEDITOR.dom.element(nativeEvent.target);
         const widget = payload.editor.get('nativeEditor').widgets.getByElement(target);
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31245](https://jira.ez.no/browse/EZP-31245)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The solution from admin-UI PR https://github.com/ezsystems/ezplatform-admin-ui/pull/1179.
PR for eZ Platform  3.0

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
