### PR TITLE
EZP-30882: Added loading thumbnails to CoreSetupFactoryTrait

### DIFF
--- a/tests/integration/eZ/API/SetupFactory/CoreSetupFactoryTrait.php
+++ b/tests/integration/eZ/API/SetupFactory/CoreSetupFactoryTrait.php
@@ -54,6 +54,7 @@ trait CoreSetupFactoryTrait
         $loader->load('storage_engines/shortcuts.yml');
         $loader->load('search_engines/common.yml');
         $loader->load('settings.yml');
+        $loader->load('thumbnails.yml');
         $loader->load('utils.yml');
         $loader->load('tests/common.yml');
         $loader->load('policies.yml');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30882](https://jira.ez.no/browse/EZP-30882)
| **Bug/Improvement**| fix failing tests
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | should
| **Doc needed**     | no

Tests are currently failing on master: https://travis-ci.org/ezsystems/ezplatform-richtext/builds/633634372?utm_source=slack&utm_medium=notification with an error:
```
Exception: Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: The service "ezpublish.api.inner_repository" has a dependency on a non-existent service "eZ\Publish\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy". in /home/travis/build/ezsystems/ezplatform-richtext/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:86
```

This PR tries to fix that 😛 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
