### PR TITLE
EZP-30130: Added handling of soft breaks inside nested formatting within paragraphs

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -109,6 +109,26 @@
     </para>
   </xsl:template>
 
+  <xsl:template match="ezxhtml5:span">
+    <xsl:choose>
+      <xsl:when test="descendant::ezxhtml5:br">
+        <xsl:for-each select="node()">
+          <xsl:choose>
+            <xsl:when test="local-name( current() ) = 'br'">
+              <xsl:text>&#xA;</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:apply-templates select="current()"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template match="ezxhtml5:pre">
     <xsl:element name="programlisting">
       <xsl:if test="@id">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -110,23 +110,9 @@
   </xsl:template>
 
   <xsl:template match="ezxhtml5:span">
-    <xsl:choose>
-      <xsl:when test="descendant::ezxhtml5:br">
-        <xsl:for-each select="node()">
-          <xsl:choose>
-            <xsl:when test="local-name( current() ) = 'br'">
-              <xsl:text>&#xA;</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:apply-templates select="current()"/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:for-each>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:apply-templates/>
-      </xsl:otherwise>
-    </xsl:choose>
+    <xsl:call-template name="breakline">
+      <xsl:with-param name="node" select="node()"/>
+    </xsl:call-template>
   </xsl:template>
 
   <xsl:template match="ezxhtml5:pre">

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/006-paragraph.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/006-paragraph.docbook.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+        version="5.0-variant ezpublish-1.0">
+  <para><literallayout class="normal">Some text
+with line break.</literallayout></para>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/006-paragraph.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/006-paragraph.xhtml5.edit.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+    <p><span><span>Some text<br/>with line break.</span></span></p>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30130](https://jira.ez.no/browse/EZP-30130)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1, master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

As we allow having soft breaks within clean paragraphs and we flush inline tags, we can also avoid validation crashes by checking line breaks inside nested `<span>` tags coming from external editors like Word. Behavior is the same as with `<p>text[soft_break]more text</p>` formatting.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
