### PR TITLE
EZP-31293: Defined UI translation label for the custom CSS classes

### DIFF
--- a/src/bundle/Resources/translations/online_editor.en.xlf
+++ b/src/bundle/Resources/translations/online_editor.en.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file date="2022-01-15T09:55:58Z" source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="f13da4dea5baa8b47c34dc4b645df71d5d07d66e" resname="ezrichtext.classes.class.label">
+        <source>Custom Classes</source>
+        <target>Custom Classes</target>
+        <note>key: ezrichtext.classes.class.label</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31293](https://jira.ez.no/browse/EZP-31293)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

## Steps to reproduce:
1. Setup some custom CSS classes, for example:
    ```
    system:
        default:
            fieldtypes:
                ezrichtext:
                    classes:
                        paragraph:
                            choices: [custom-paragraph-1, custom-paragraph-2, custom-paragraph-3]
                            default_value: custom-paragraph-1
                            required: false
                            multiple: false {code}
    ```
2. Open Online Editor and try to set a custom CSS class for a paragraph

##  Expected result
The text label for custom classes will be shown.

## Actual result
*ezrichtext.classes.class.label* is shown, instead of text label.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.