### PR TITLE
EZEE-2914: Custom inline style does not update textarea after click on

### DIFF
--- a/src/bundle/Resources/encore/ez.config.js
+++ b/src/bundle/Resources/encore/ez.config.js
@@ -25,6 +25,7 @@ module.exports = (Encore) => {
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-underline.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-subscript.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-superscript.js'),
+        path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-quote.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-strike.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-link.js'),

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import AlloyEditor from 'alloyeditor';
+
+export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListItem {
+    /**
+     * Lifecycle. Renders the UI of the button.
+     *
+     * @instance
+     * @memberof ButtonStylesListItem
+     * @method render
+     * @return {Object} The content which should be rendered.
+     */
+    render() {
+        const className = this.props.name === this.props.activeStyle ? 'ae-toolbar-element active' : 'ae-toolbar-element';
+
+        return (
+            <button
+                className={className}
+                dangerouslySetInnerHTML={{ __html: this._preview }}
+                onClick={() => {
+                    this._onClick();
+                    this.fireCustomUpdateEvent();
+                }}
+                tabIndex={this.props.tabIndex}
+            />
+        );
+    }
+
+    fireCustomUpdateEvent() {
+        const nativeEditor = this.props.editor.get('nativeEditor');
+
+        nativeEditor.fire('customUpdate');
+    }
+}
+
+AlloyEditor.ButtonStylesListItem = AlloyEditor.EzBtnStylesListItem = EzBtnStylesListItem;
+eZ.addConfig('ezAlloyEditor.ezBtnStylesListItem', EzBtnStylesListItem);

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import AlloyEditor from 'alloyeditor';
+import EzBtnLink from "./ez-btn-link";
 
 export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListItem {
     /**
@@ -34,4 +35,8 @@ export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListIte
 }
 
 AlloyEditor.ButtonStylesListItem = AlloyEditor.EzBtnStylesListItem = EzBtnStylesListItem;
-eZ.addConfig('ezAlloyEditor.ezBtnStylesListItem', EzBtnStylesListItem);
+
+const eZ = (window.eZ = window.eZ || {});
+
+eZ.ezAlloyEditor = eZ.ezAlloyEditor || {};
+eZ.ezAlloyEditor.ezBtnStylesListItem = EzBtnStylesListItem;

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import AlloyEditor from 'alloyeditor';
-import EzBtnLink from "./ez-btn-link";
 
 export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListItem {
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-2914](https://jira.ez.no/browse/EZEE-2914)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master target 3.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

AlloyEditor.ButtonStylesListItem on click does not update textarea element, because function _onClick is protected and we cannot override, so we need an override render function, for add a new function into onClick in order to update textarea

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
