### PR TITLE
EZP-31295: Unable to use default empty custom CSS class in the OE

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-attributes-update.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-attributes-update.js
@@ -143,7 +143,13 @@ export default class EzBtnAttributesUpdate extends EzWidgetButton {
             return;
         }
 
-        block.$.classList.remove(...this.classes.choices);
+        const classList = block.$.classList;
+
+        this.classes.choices.forEach((className) => {
+            if (classList.contains(className)) {
+                classList.remove(className);
+            }
+        });
     }
 
     saveValues() {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31295](https://jira.ez.no/browse/EZP-31295)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
