### PR TITLE
EZP-31321: Dropped injecting zero-width space into ezembed(inline) elements

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/plugins/ez-custom-tag.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/plugins/ez-custom-tag.js
@@ -1,7 +1,5 @@
 import customTagBaseDefinition from './base/ez-custom-tag-base';
 
-const ZERO_WIDTH_SPACE = '&#8203;';
-
 CKEDITOR.dtd.$editable.span = 1;
 
 (function(global) {

--- a/src/bundle/Resources/public/js/OnlineEditor/plugins/ez-embed.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/plugins/ez-embed.js
@@ -1,7 +1,5 @@
 import embedBaseDefinition from './base/ez-embed-base';
 
-const ZERO_WIDTH_SPACE = '&#8203;';
-
 (function(global) {
     if (CKEDITOR.plugins.get('ezembed') && CKEDITOR.plugins.get('ezembedinline')) {
         return;
@@ -64,7 +62,6 @@ const ZERO_WIDTH_SPACE = '&#8203;';
                 },
 
                 insertWrapper: function(wrapper) {
-                    this.editor.insertHtml(ZERO_WIDTH_SPACE);
                     this.editor.insertElement(wrapper);
                 },
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31321](https://jira.ez.no/browse/EZP-31321)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Ask for Code Review.
