### PR TITLE
EZP-30222: Handled tables copied from external sources

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -397,15 +397,13 @@
           </xsl:call-template>
         </xsl:variable>
         <xsl:if test="$width != ''">
+          <xsl:variable name="normalizedWidth">
+            <xsl:call-template name="normalizeWidth">
+              <xsl:with-param name="width" select="$width"/>
+            </xsl:call-template>
+          </xsl:variable>
           <xsl:attribute name="width">
-            <xsl:choose>
-              <xsl:when test="substring( $width, string-length( $width ) - 1 ) = 'px'">
-                <xsl:value-of select="substring-before( $width, 'px' )"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="$width"/>
-              </xsl:otherwise>
-            </xsl:choose>
+            <xsl:value-of select="$normalizedWidth"/>
           </xsl:attribute>
         </xsl:if>
       </xsl:if>
@@ -414,7 +412,7 @@
           <xsl:value-of select="@title"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="@border != ''">
+      <xsl:if test="(@border != '') or (contains( @style, 'border:' ))">
         <xsl:attribute name="border">1</xsl:attribute>
       </xsl:if>
       <xsl:if test="contains( @style, 'border-width:' )">
@@ -477,7 +475,7 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="contains( @style, 'width' )">
+      <xsl:if test="contains( @style, 'width:' )">
         <xsl:variable name="width">
           <xsl:call-template name="extractStyleValue">
             <xsl:with-param name="style" select="@style"/>
@@ -485,15 +483,13 @@
           </xsl:call-template>
         </xsl:variable>
         <xsl:if test="$width != ''">
+          <xsl:variable name="normalizedWidth">
+            <xsl:call-template name="normalizeWidth">
+              <xsl:with-param name="width" select="$width"/>
+            </xsl:call-template>
+          </xsl:variable>
           <xsl:attribute name="ezxhtml:width">
-            <xsl:choose>
-              <xsl:when test="substring( $width, string-length( $width ) - 1 ) = 'px'">
-                <xsl:value-of select="substring-before( $width, 'px' )"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="$width"/>
-              </xsl:otherwise>
-            </xsl:choose>
+            <xsl:value-of select="$normalizedWidth"/>
           </xsl:attribute>
         </xsl:if>
       </xsl:if>
@@ -551,16 +547,14 @@
             <xsl:with-param name="property" select="'width'"/>
           </xsl:call-template>
         </xsl:variable>
-        <xsl:if test="$width != ''">
+        <xsl:variable name="normalizedWidth">
+          <xsl:call-template name="normalizeWidth">
+            <xsl:with-param name="width" select="$width"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:if test="$normalizedWidth != ''">
           <xsl:attribute name="ezxhtml:width">
-            <xsl:choose>
-              <xsl:when test="substring( $width, string-length( $width ) - 1 ) = 'px'">
-                <xsl:value-of select="substring-before( $width, 'px' )"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="$width"/>
-              </xsl:otherwise>
-            </xsl:choose>
+            <xsl:value-of select="$normalizedWidth"/>
           </xsl:attribute>
         </xsl:if>
       </xsl:if>
@@ -758,6 +752,21 @@
     <xsl:param name="style"/>
     <xsl:param name="property"/>
     <xsl:value-of select="translate( substring-before( substring-after( concat( substring-after( $style, $property ), ';' ), ':' ), ';' ), ' ', '' )"/>
+  </xsl:template>
+
+  <xsl:template name="normalizeWidth">
+    <xsl:param name="width"/>
+    <xsl:choose>
+      <xsl:when test="substring( $width, string-length( $width ) - 1 ) = 'px'">
+        <xsl:value-of select="format-number(number(substring-before( $width, 'px' )), '#')"/>
+      </xsl:when>
+      <xsl:when test="substring( $width, string-length( $width ) - 1 ) = 'pt'">
+        <xsl:value-of select="format-number(number(substring-before( $width, 'pt' )) * 1.33, '#')"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$width"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <!-- Some fallbacks to handle translating inline formatting in span tags for copy&paste and import use cases -->

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -760,7 +760,7 @@
         <xsl:value-of select="round(substring-before( $width, 'px' ))"/>
       </xsl:when>
       <xsl:when test="substring( $width, string-length( $width ) - 1 ) = 'pt'">
-        <xsl:value-of select="round(substring-before( $width, 'pt' )) * 1.33"/>
+        <xsl:value-of select="round(substring-before( $width, 'pt' ) * 1.33)"/>
       </xsl:when>
       <xsl:when test="substring( $width, string-length( $width ) ) = '%'">
         <xsl:value-of select="concat(round(substring-before( $width, '%' )), '%')"/>

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -39,7 +39,6 @@
       </xsl:element>
     </xsl:if>
   </xsl:template>
-
   <xsl:template name="breakline">
     <xsl:param name="node"/>
     <xsl:choose>
@@ -758,15 +757,28 @@
     <xsl:param name="width"/>
     <xsl:choose>
       <xsl:when test="substring( $width, string-length( $width ) - 1 ) = 'px'">
-        <xsl:value-of select="format-number(number(substring-before( $width, 'px' )), '#')"/>
+        <xsl:value-of select="round(substring-before( $width, 'px' ))"/>
       </xsl:when>
       <xsl:when test="substring( $width, string-length( $width ) - 1 ) = 'pt'">
-        <xsl:value-of select="format-number(number(substring-before( $width, 'pt' )) * 1.33, '#')"/>
+        <xsl:value-of select="round(substring-before( $width, 'pt' )) * 1.33"/>
+      </xsl:when>
+      <xsl:when test="substring( $width, string-length( $width ) ) = '%'">
+        <xsl:value-of select="concat(round(substring-before( $width, '%' )), '%')"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="$width"/>
+        <xsl:variable name="strippedWidth">
+          <xsl:call-template name="stripUnits">
+            <xsl:with-param name="inputString" select="$width"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:value-of select="round($strippedWidth)"/>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="stripUnits">
+    <xsl:param name="inputString"/>
+    <xsl:value-of select="translate($inputString, translate($inputString, '0123456789%.', ''), '')"/>
   </xsl:template>
 
   <!-- Some fallbacks to handle translating inline formatting in span tags for copy&paste and import use cases -->

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/007-table.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/007-table.docbook.xml
@@ -14,6 +14,15 @@
 with a breakline</literallayout>
                     </para>
                 </th>
+                <th ezxhtml:width="100">
+                    <para>test heading with different width unit</para>
+                </th>
+                <th ezxhtml:width="100">
+                    <para>another test heading with different width unit</para>
+                </th>
+                <th ezxhtml:width="100">
+                    <para>another test heading with dummy width unit</para>
+                </th>
             </tr>
         </thead>
         <tbody>
@@ -23,6 +32,15 @@ with a breakline</literallayout>
                         <literallayout class="normal">test cell
 with a breakline</literallayout>
                     </para>
+                </td>
+                <td ezxhtml:width="100">
+                    <para>test cell with different width unit</para>
+                </td>
+                <td ezxhtml:width="100">
+                    <para>another test cell with different width unit</para>
+                </td>
+                <td ezxhtml:width="100">
+                    <para>another test cell with dummy width unit</para>
                 </td>
             </tr>
         </tbody>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/007-table.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/007-table.docbook.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+        version="5.0-variant ezpublish-1.0">
+    <informaltable width="100%" border="1">
+        <thead>
+            <tr>
+                <th ezxhtml:width="133">
+                    <para>
+                        <literallayout class="normal">test heading
+with a breakline</literallayout>
+                    </para>
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td ezxhtml:width="100">
+                    <para>
+                        <literallayout class="normal">test cell
+with a breakline</literallayout>
+                    </para>
+                </td>
+            </tr>
+        </tbody>
+    </informaltable>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/007-table.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/007-table.xhtml5.edit.xml
@@ -1,22 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-    <table style="border: 1 px solid black; width: 100%;">
+    <table style="border: 1 px solid black; width: 100.3%;">
         <thead>
             <tr>
-                <th style="width: 100pt">
+                <th style="width: 100.3pt">
                     <p>
                         <span>test heading<br/>with a breakline</span>
+                    </p>
+                </th>
+                <th style="width: 100em">
+                    <p>
+                        <span>test heading with different width unit</span>
+                    </p>
+                </th>
+                <th style="width: 100rem">
+                    <p>
+                        <span>another test heading with different width unit</span>
+                    </p>
+                </th>
+                <th style="width: 100.3dummyUnit">
+                    <p>
+                        <span>another test heading with dummy width unit</span>
                     </p>
                 </th>
             </tr>
         </thead>
         <tbody>
             <tr>
-                <td style="width: 100px;">
+                <td style="width: 100.3px;">
                     <p>
                         <span>test cell<br/>with a breakline</span>
                     </p>
-
+                </td>
+                <td style="width: 100em">
+                    <p>
+                        <span>test cell with different width unit</span>
+                    </p>
+                </td>
+                <td style="width: 100.3rem">
+                    <p>
+                        <span>another test cell with different width unit</span>
+                    </p>
+                </td>
+                <td style="width: 100.3dummyUnit">
+                    <p>
+                        <span>another test cell with dummy width unit</span>
+                    </p>
                 </td>
             </tr>
         </tbody>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/007-table.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/007-table.xhtml5.edit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+    <table style="border: 1 px solid black; width: 100%;">
+        <thead>
+            <tr>
+                <th style="width: 100pt">
+                    <p>
+                        <span>test heading<br/>with a breakline</span>
+                    </p>
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td style="width: 100px;">
+                    <p>
+                        <span>test cell<br/>with a breakline</span>
+                    </p>
+
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30222](https://jira.ez.no/browse/EZP-30222)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1, master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR  introduces a slightly different way of handling table width:
- introducing `normalizeWidth` function which handles `px` and `pt` units as these are the main ones used in tables,
- rounding width values, e.g. `110.5pt`,
- taking `style="border: [thickness] [style] [color];"` property from CSS into account and applying `border="1px"` to make things consistent with the tables generated by RTE by default.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
