### PR TITLE
EZP-31272: Handled anchors generated with name attribute

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -258,22 +258,13 @@
   <xsl:template name="link.anchor">
     <xsl:param name="attribute"/>
     <anchor>
-      <xsl:choose>
-        <xsl:when test="boolean(//ezxhtml5:a[@name = preceding::ezxhtml5:a/@name or ./ezxhtml5:a/@name = following::ezxhtml5:a/@name] ) = false()">
-          <xsl:attribute name="xml:id">
-            <xsl:value-of select="$attribute"/>
-          </xsl:attribute>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:message terminate="yes">
-            Anchor names must be unique. Check duplicates and re-publish the content.
-          </xsl:message>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:attribute name="xml:id">
+        <xsl:value-of select="$attribute"/>
+      </xsl:attribute>
     </anchor>
   </xsl:template>
 
-  <xsl:template match="ezxhtml5:a">
+  <xsl:template match="ezxhtml5:a[not(@name=preceding::ezxhtml5:a/@name)]">
     <xsl:choose>
       <xsl:when test="@href">
         <xsl:call-template name="link.href"/>

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -256,9 +256,10 @@
   </xsl:template>
 
   <xsl:template name="link.anchor">
+    <xsl:param name="attribute"/>
     <anchor>
       <xsl:attribute name="xml:id">
-        <xsl:value-of select="@id"/>
+        <xsl:value-of select="$attribute"/>
       </xsl:attribute>
     </anchor>
   </xsl:template>
@@ -269,7 +270,14 @@
         <xsl:call-template name="link.href"/>
       </xsl:when>
       <xsl:when test="@id">
-        <xsl:call-template name="link.anchor"/>
+        <xsl:call-template name="link.anchor">
+          <xsl:with-param name="attribute" select="@id"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="@name">
+        <xsl:call-template name="link.anchor">
+          <xsl:with-param name="attribute" select="@name"/>
+        </xsl:call-template>
       </xsl:when>
       <xsl:otherwise>
         <xsl:message terminate="yes">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -258,9 +258,18 @@
   <xsl:template name="link.anchor">
     <xsl:param name="attribute"/>
     <anchor>
-      <xsl:attribute name="xml:id">
-        <xsl:value-of select="$attribute"/>
-      </xsl:attribute>
+      <xsl:choose>
+        <xsl:when test="boolean(//ezxhtml5:a[@name = preceding::ezxhtml5:a/@name or ./ezxhtml5:a/@name = following::ezxhtml5:a/@name] ) = false()">
+          <xsl:attribute name="xml:id">
+            <xsl:value-of select="$attribute"/>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:message terminate="yes">
+            Anchor names must be unique. Check duplicates and re-publish the content.
+          </xsl:message>
+        </xsl:otherwise>
+      </xsl:choose>
     </anchor>
   </xsl:template>
 

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.docbook.xml
@@ -5,7 +5,7 @@
         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
         version="5.0-variant ezpublish-1.0">
-    <para>
-        <anchor xml:id="top"/>some anchor with a name attribute.
-    </para>
+    <para><anchor xml:id="top"/>some anchor with a name attribute.</para>
+    <para><anchor xml:id="bottom"/>some anchor with a name attribute.</para>
+    <para>another anchor that should be removed due to lack of name uniqueness.</para>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.docbook.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section
+        xmlns="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+        version="5.0-variant ezpublish-1.0">
+    <para>
+        <anchor xml:id="top"/>some anchor with a name attribute.
+    </para>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.xhtml5.edit.xml
@@ -3,4 +3,7 @@
     <p>
         <a name="top"/>some anchor with a name attribute.
     </p>
+    <p>
+        <a name="top"/>another anchor with the same name attribute.
+    </p>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.xhtml5.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+    <p>
+        <a name="top"/>some anchor with a name attribute.
+    </p>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.xhtml5.edit.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-    <p>
-        <a name="top"/>some anchor with a name attribute.
-    </p>
-    <p>
-        <a name="top"/>another anchor with the same name attribute.
-    </p>
+    <p><a name="top"/>some anchor with a name attribute.</p>
+    <p><a name="bottom"/>some anchor with a name attribute.</p>
+    <p><a name="bottom"/>another anchor that should be removed due to lack of name uniqueness.</p>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31272](https://jira.ez.no/browse/EZP-31272)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1, master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently, anchors pasted from external sources often contain `name` attribute: `<a name="test">`. Since we only support `id` attribute I decided to add a simple mapping that prevents RTE validation from crushing.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
