### PR TITLE
EZP-31278: Removed usage of the obsolete RegisterLimitationTypePass

### DIFF
--- a/tests/integration/eZ/API/SetupFactory/CoreSetupFactoryTrait.php
+++ b/tests/integration/eZ/API/SetupFactory/CoreSetupFactoryTrait.php
@@ -85,7 +85,6 @@ trait CoreSetupFactoryTrait
 
         $containerBuilder->addCompilerPass(new Compiler\FieldTypeRegistryPass());
         $containerBuilder->addCompilerPass(new Compiler\Persistence\FieldTypeRegistryPass());
-        $containerBuilder->addCompilerPass(new Compiler\RegisterLimitationTypePass());
 
         $containerBuilder->addCompilerPass(new Compiler\Storage\ExternalStorageRegistryPass());
         $containerBuilder->addCompilerPass(new Compiler\Storage\Legacy\FieldValueConverterRegistryPass());


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31278](https://jira.ez.no/browse/EZP-31278)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master` for eZ Platform `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR removes the usage of the RegisterLimitationTypePass which has been dropped via ezsystems/ezpublish-kernel#2914.

### QA

Affects test setup only, so if passes, can be merged as-is.

**TODO**:
- [x] Drop usage of Kernel's `RegisterLimitationTypePass` from the integration test setup.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
