### PR TITLE
EZP-31129: Removed outdated URLs when storing Field data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "php": "^7.1",
         "ext-xsl": "*",
         "ext-dom": "*",
+        "ext-libxml": "*",
         "symfony/symfony": "^3.4",
         "ezsystems/ezpublish-kernel": "^7.4@dev",
         "ezsystems/repository-forms": "^2.0"

--- a/src/lib/eZ/FieldType/RichText/RichTextStorage.php
+++ b/src/lib/eZ/FieldType/RichText/RichTextStorage.php
@@ -57,10 +57,6 @@ class RichTextStorage extends GatewayBasedStorage
 
         $links = $xpath->query($xpathExpression);
 
-        if ($versionInfo->versionNo !== 1) {
-            $this->gateway->unlinkUrl($field->id, $versionInfo->versionNo);
-        }
-
         if (empty($links)) {
             return false;
         }
@@ -116,6 +112,14 @@ class RichTextStorage extends GatewayBasedStorage
 
             $link->setAttribute('xlink:href', $href);
         }
+
+        $this->gateway->unlinkUrl(
+            $field->id,
+            $versionInfo->versionNo,
+            array_values(
+                $urlIdMap
+            )
+        );
 
         $field->value->data = $document->saveXML();
 

--- a/src/lib/eZ/FieldType/RichText/RichTextStorage.php
+++ b/src/lib/eZ/FieldType/RichText/RichTextStorage.php
@@ -57,6 +57,10 @@ class RichTextStorage extends GatewayBasedStorage
 
         $links = $xpath->query($xpathExpression);
 
+        if ($versionInfo->versionNo !== 1) {
+            $this->gateway->unlinkUrl($field->id, $versionInfo->versionNo);
+        }
+
         if (empty($links)) {
             return false;
         }

--- a/src/lib/eZ/FieldType/RichText/RichTextStorage/Gateway.php
+++ b/src/lib/eZ/FieldType/RichText/RichTextStorage/Gateway.php
@@ -95,9 +95,10 @@ abstract class Gateway extends StorageGateway
      *
      * @param int|string $fieldId
      * @param int $versionNo
+     * @param array|null $excludeUrlIds
      */
-    public function unlinkUrl($fieldId, $versionNo)
+    public function unlinkUrl($fieldId, $versionNo, $excludeUrlIds = null)
     {
-        $this->urlGateway->unlinkUrl($fieldId, $versionNo);
+        $this->urlGateway->unlinkUrl($fieldId, $versionNo, $excludeUrlIds);
     }
 }

--- a/src/lib/eZ/FieldType/RichText/RichTextStorage/Gateway.php
+++ b/src/lib/eZ/FieldType/RichText/RichTextStorage/Gateway.php
@@ -95,9 +95,9 @@ abstract class Gateway extends StorageGateway
      *
      * @param int|string $fieldId
      * @param int $versionNo
-     * @param array|null $excludeUrlIds
+     * @param int[] $excludeUrlIds
      */
-    public function unlinkUrl($fieldId, $versionNo, $excludeUrlIds = null)
+    public function unlinkUrl($fieldId, $versionNo, array $excludeUrlIds = [])
     {
         $this->urlGateway->unlinkUrl($fieldId, $versionNo, $excludeUrlIds);
     }

--- a/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
@@ -636,7 +636,7 @@ EOT;
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testExternalLinkStoringAfterUpdate()
+    public function testExternalLinkStoringAfterUpdate(): void
     {
         $xmlDocument = $this->createXmlDocumentWithExternalLink();
         $repository = $this->getRepository();
@@ -944,7 +944,7 @@ EOT;
     /**
      * @return \DOMDocument
      */
-    private function createXmlDocumentWithExternalLink()
+    private function createXmlDocumentWithExternalLink(): DOMDocument
     {
         $document = new DOMDocument();
         $document->preserveWhiteSpace = false;

--- a/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
@@ -642,7 +642,7 @@ EOT;
      */
     public function testExternalLinkStoringAfterUpdate(): void
     {
-        $xmlDocument = $this->createXmlDocumentWithExternalLink('https://ez.no/');
+        $xmlDocument = $this->createXmlDocumentWithExternalLink(['https://ez.no/', 'https://support.ez.no/']);
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
 
@@ -667,7 +667,7 @@ EOT;
             $content->contentInfo->currentVersionNo
         );
 
-        $xmlDocument = $this->createXmlDocumentWithExternalLink('https://support.ez.no/');
+        $xmlDocument = $this->createXmlDocumentWithExternalLink(['https://support.ez.no/']);
         $contentUpdateStruct = $contentService->newContentUpdateStruct();
         $contentUpdateStruct->setField('description', $xmlDocument, 'eng-GB');
         $contentDraft = $contentService->updateContent(
@@ -977,15 +977,22 @@ EOT;
     }
 
     /**
-     * @param string $url
+     * @param array $urls
      *
      * @return \DOMDocument
      */
-    private function createXmlDocumentWithExternalLink(string $url): DOMDocument
+    private function createXmlDocumentWithExternalLink(array $urls): DOMDocument
     {
         $document = new DOMDocument();
         $document->preserveWhiteSpace = false;
         $document->formatOutput = false;
+        $links = '';
+        foreach ($urls as $url) {
+            $links .= sprintf(
+                '<link xlink:href="%s" xlink:show="none" xlink:title="">%1$s</link>',
+                $url
+            );
+        }
         $document->loadXML(
             (<<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -996,7 +1003,7 @@ EOT;
     xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" 
     version="5.0-variant ezpublish-1.0">
         <para>
-            <link xlink:href="$url" xlink:show="none" xlink:title="">link</link>
+            $links
         </para>
     </section>
 

--- a/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
@@ -676,14 +676,14 @@ EOT;
 
         $contentUpdateStruct = $contentService->newContentUpdateStruct();
         $contentUpdateStruct->setField('description', $xmlDocument, 'eng-GB');
-        $contentDraftB = $contentService->updateContent(
+        $contentDraft = $contentService->updateContent(
                 $contentService->createContentDraft($content->contentInfo)->versionInfo,
                 $contentUpdateStruct
             );
-        $content = $contentService->publishVersion($contentDraftB->versionInfo);
-        $mapIdsAfterUpdate = $this->getUrlIdsForContentObjectAttributeIdAndVersionNo($content->getField('description')->id, $content->contentInfo->currentVersionNo);
+        $content = $contentService->publishVersion($contentDraft->versionInfo);
+        $urlIdsAfterUpdate = $this->getUrlIdsForContentObjectAttributeIdAndVersionNo($content->getField('description')->id, $content->contentInfo->currentVersionNo);
 
-        $this->assertEquals($urlIds, $mapIdsAfterUpdate);
+        $this->assertEquals($urlIds, $urlIdsAfterUpdate);
     }
 
     /**

--- a/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
@@ -720,8 +720,6 @@ EOT;
     }
 
     /**
-     * @param $contentObjectAttributeId
-     * @param $versionNo
      *
      * @return int[]
      *

--- a/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
@@ -720,7 +720,6 @@ EOT;
     }
 
     /**
-     *
      * @return int[]
      *
      * @throws \ErrorException

--- a/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
@@ -636,7 +636,7 @@ EOT;
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testExternalLinkCorrectStoreAfterUpdate()
+    public function testExternalLinkStoringAfterUpdate()
     {
         $xmlDocument = $this->createXmlDocumentWithExternalLink();
         $repository = $this->getRepository();
@@ -663,28 +663,11 @@ EOT;
         $contentTypeService->publishContentTypeDraft($contentTypeDraft);
         $testContentType = $contentTypeService->loadContentType($contentTypeDraft->id);
 
-        // Create a folder for tests
-        $contentTypeCreateStruct = $contentService->newContentCreateStruct(
-            $contentTypeService->loadContentTypeByIdentifier('folder'),
-            'eng-GB'
-        );
-
-        $contentTypeCreateStruct->setField('name', 'Folder Link');
-        $draft = $contentService->createContent(
-            $contentTypeCreateStruct,
-            [$locationService->newLocationCreateStruct(2)]
-        );
-
-        $folder = $contentService->publishVersion(
-            $draft->versionInfo
-        );
-        $locationId = $folder->versionInfo->contentInfo->mainLocationId;
-
         $testContentCreateStruct = $contentService->newContentCreateStruct($testContentType, 'eng-GB');
         $testContentCreateStruct->setField('description', $xmlDocument, 'eng-GB');
         $content = $contentService->createContent(
             $testContentCreateStruct,
-            [$locationService->newLocationCreateStruct($locationId)]
+            [$locationService->newLocationCreateStruct(2)]
         );
         $content = $contentService->publishVersion(
             $content->versionInfo

--- a/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/eZ/API/RichTextFieldTypeIntegrationTest.php
@@ -693,7 +693,7 @@ EOT;
 
         $contentUpdateStruct = $contentService->newContentUpdateStruct();
         $contentUpdateStruct->setField('description', $xmlDocument, 'eng-GB');
-            $contentDraftB = $contentService->updateContent(
+        $contentDraftB = $contentService->updateContent(
                 $contentService->createContentDraft($content->contentInfo)->versionInfo,
                 $contentUpdateStruct
             );
@@ -706,7 +706,9 @@ EOT;
     /**
      * @param int $contentObjectAttributeId
      * @param int $versionNo
+     *
      * @return array
+     *
      * @throws \ErrorException
      */
     private function getUrlObjectLinkForContentObjectAttributeIdAndVersionNo(int $contentObjectAttributeId, int $versionNo): array
@@ -728,6 +730,7 @@ EOT;
         foreach ($statement->fetchAll(FetchMode::ASSOCIATIVE) as $row) {
             $map[] = $row['url_id'];
         }
+
         return $map;
     }
 
@@ -955,7 +958,6 @@ EOT;
         self::fail("Expected ValidationError '{$expectedValidationErrorMessage}' didn't occur");
     }
 
-
     /**
      * @return \DOMDocument
      */
@@ -979,9 +981,9 @@ EOT;
 
 XML
         ), LIBXML_NOENT);
+
         return $document;
     }
-
 
     /**
      * Get XML Document in DocBook format, containing link to the given Location.

--- a/tests/lib/eZ/FieldType/RichText/RichTextStorageTest.php
+++ b/tests/lib/eZ/FieldType/RichText/RichTextStorageTest.php
@@ -197,10 +197,6 @@ class RichTextStorageTest extends TestCase
         $gateway = $this->getGatewayMock();
         $gateway
             ->expects($this->at($gatewayCallIndex++))
-            ->method('unlinkUrl')
-            ->with(42, 24);
-        $gateway
-            ->expects($this->at($gatewayCallIndex++))
             ->method('getUrlIdMap')
             ->with($this->equalTo($linkUrls))
             ->willReturn($linkIds);
@@ -222,6 +218,7 @@ class RichTextStorageTest extends TestCase
                     ->method('insertUrl')
                     ->with($this->equalTo($url))
                     ->willReturn($id);
+                $linkIds[$url] = $id;
             } else {
                 $id = $linkIds[$url];
             }
@@ -231,6 +228,16 @@ class RichTextStorageTest extends TestCase
                 ->method('linkUrl')
                 ->with($id, 42, 24);
         }
+        $gateway
+            ->expects($this->at($gatewayCallIndex))
+            ->method('unlinkUrl')
+            ->with(
+                42,
+                24,
+                array_values(
+                    $linkIds
+                )
+            );
 
         $storage = $this->getPartlyMockedStorage($gateway);
         $result = $storage->storeFieldData(

--- a/tests/lib/eZ/FieldType/RichText/RichTextStorageTest.php
+++ b/tests/lib/eZ/FieldType/RichText/RichTextStorageTest.php
@@ -195,7 +195,10 @@ class RichTextStorageTest extends TestCase
         $value = new FieldValue(['data' => $xmlString]);
         $field = new Field(['id' => 42, 'value' => $value]);
         $gateway = $this->getGatewayMock();
-
+        $gateway
+            ->expects($this->at($gatewayCallIndex++))
+            ->method('unlinkUrl')
+            ->with(42, 24);
         $gateway
             ->expects($this->at($gatewayCallIndex++))
             ->method('getUrlIdMap')


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31129](https://jira.ez.no/browse/EZP-31129)
| **Requires** | ezsystems/ezpublish-kernel#2957
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Depends on: https://github.com/ezsystems/ezpublish-kernel/pull/2957

When editing ContentType from RichText which has links. In the link manager,  links are still there from the previous version, because when creating a draft, the links from the current version are moved to the new version and when saving there is no verification which links exist and which ones do not, therefore when saving data from RichText, the removal of links from the current version has been added to save links from RichText


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
