### PR TITLE
EZP-31137: Fixed styles dropdown when custom ones are in use for RTE

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js
@@ -18,12 +18,24 @@ export default class EzBtnStylesListItem extends AlloyEditor.ButtonStylesListIte
                 className={className}
                 dangerouslySetInnerHTML={{ __html: this._preview }}
                 onClick={() => {
+                    this.clearEzAttributes();
                     this._onClick();
                     this.fireCustomUpdateEvent();
                 }}
                 tabIndex={this.props.tabIndex}
             />
         );
+    }
+
+    clearEzAttributes() {
+        const nativeEditor = this.props.editor.get('nativeEditor');
+        const block = nativeEditor.elementPath().block;
+        const attrsToRemove = ['ezelement', 'eztype', 'ezname'];
+        const targetName = this.props.style.attributes ? this.props.style.attributes['data-ezname'] : '';
+
+        if (block.$.dataset.eztype === 'style' && block.$.dataset.ezname !== targetName) {
+            attrsToRemove.forEach(attr => block.$.removeAttribute(`data-${attr}`));
+        }
     }
 
     fireCustomUpdateEvent() {

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-custom-style.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-custom-style.js
@@ -20,16 +20,6 @@ export default class EzCustomStyleConfig extends EzConfigBase {
         this.addExtraButtons(config.extraButtons);
     }
 
-    getStyles(customStyles = []) {
-        return {
-            name: 'styles',
-            cfg: {
-                showRemoveStylesItem: false,
-                styles: [...customStyles],
-            },
-        };
-    }
-
     /**
      * Tests whether the `custom style` toolbar should be visible. It is
      * visible when an existing custom style gets the focus.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31137](https://jira.ez.no/browse/EZP-31137)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | latest stable for bug fixes, master for new features
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |no

ez-custom-style.js for alloy editor was overriding base config styles by filtering out default styles unnecessarily if custom styles were in use.

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
