### PR TITLE
EZP-31380: Disable manage rows/cells buttons for table and row toolbars

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
@@ -13,9 +13,6 @@ export default class EzConfigTableBase {
             'tableHeading',
             'ezembedinline',
             'ezanchor',
-            'eztablerow',
-            'eztablecolumn',
-            'eztablecell',
             'eztableremove',
             ...config.extraButtons[this.name],
         ];

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-table-cell.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-table-cell.js
@@ -1,6 +1,26 @@
 import EzConfigTableBase from './base-table';
 
 export default class EzTableCellConfig extends EzConfigTableBase {
+    constructor(config) {
+        super(config);
+
+        const editAttributesButton = config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '';
+
+        this.buttons = [
+            'ezmoveup',
+            'ezmovedown',
+            editAttributesButton,
+            'tableHeading',
+            'ezembedinline',
+            'ezanchor',
+            'eztablerow',
+            'eztablecolumn',
+            'eztablecell',
+            'eztableremove',
+            ...config.extraButtons[this.name],
+        ];
+    }
+
     getConfigName() {
         return 'td';
     }

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-table-header.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-table-header.js
@@ -1,6 +1,6 @@
-import EzConfigTableBase from './base-table';
+import EzTableCellConfig from './ez-table-cell';
 
-export default class EzTableHeaderConfig extends EzConfigTableBase {
+export default class EzTableHeaderConfig extends EzTableCellConfig {
     getConfigName() {
         return 'th';
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31380](https://jira.ez.no/browse/EZP-31380)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

https://github.com/ezsystems/ezplatform-admin-ui/pull/1232

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
