### PR TITLE
EZP-31356: Fixed styles dropdown selection on Firefox and Safari

### DIFF
--- a/src/bundle/Resources/encore/ez.config.js
+++ b/src/bundle/Resources/encore/ez.config.js
@@ -25,6 +25,8 @@ module.exports = (Encore) => {
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-underline.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-subscript.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-superscript.js'),
+        path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-dropdown.js'),
+        path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-styleslist.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-styleslistitem.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-quote.js'),
         path.resolve(__dirname, '../public/js/OnlineEditor/buttons/ez-btn-strike.js'),

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-dropdown.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-dropdown.js
@@ -2,7 +2,6 @@ import React from 'react';
 import AlloyEditor from 'alloyeditor';
 
 export default class EzBtnDropdown extends AlloyEditor.ButtonDropdown {
-
     render() {
         return React.createElement("div", {
             className: "ae-dropdown ae-arrow-box ae-arrow-box-top-left",

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-dropdown.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-dropdown.js
@@ -2,12 +2,22 @@ import React from 'react';
 import AlloyEditor from 'alloyeditor';
 
 export default class EzBtnDropdown extends AlloyEditor.ButtonDropdown {
+    /**
+     * Lifecycle. Renders the UI of the button.
+     *
+     * @instance
+     * @memberof ButtonDropdown
+     * @method render
+     * @return {Object} The content which should be rendered.
+     */
     render() {
-        return React.createElement("div", {
-            className: "ae-dropdown ae-arrow-box ae-arrow-box-top-left",
-            onKeyDown: this.handleKey,
-            tabIndex: "0",
-        }, React.createElement("ul", {className: "ae-listbox", role: "listbox"}, this.props.children))
+        return (
+            <div className="ae-dropdown ae-arrow-box ae-arrow-box-top-left" onKeyDown={this.handleKey} tabIndex="0">
+                <ul className="ae-listbox" role="listbox">
+                    {this.props.children}
+                </ul>
+            </div>
+        );
     }
 }
 

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-dropdown.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-dropdown.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import AlloyEditor from 'alloyeditor';
+
+export default class EzBtnDropdown extends AlloyEditor.ButtonDropdown {
+
+    render() {
+        return React.createElement("div", {
+            className: "ae-dropdown ae-arrow-box ae-arrow-box-top-left",
+            onKeyDown: this.handleKey,
+            tabIndex: "0",
+        }, React.createElement("ul", {className: "ae-listbox", role: "listbox"}, this.props.children))
+    }
+}
+
+const eZ = (window.eZ = window.eZ || {});
+
+eZ.ezAlloyEditor = eZ.ezAlloyEditor || {};
+eZ.ezAlloyEditor.EzBtnDropdown = EzBtnDropdown;

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslist.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslist.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import AlloyEditor from 'alloyeditor';
+import EzButtonDropdown from './ez-btn-dropdown';
+
+export default class EzButtonStylesList extends AlloyEditor.ButtonStylesList {
+
+    render() {
+        var e;
+        return this.props.showRemoveStylesItem && (e = React.createElement(AlloyEditor.ButtonStylesListItemRemove, {
+            editor: this.props.editor,
+            onDismiss: this.props.toggleDropdown
+        })), React.createElement(EzButtonDropdown, this.props, e, React.createElement(AlloyEditor.ButtonsStylesListHeader, {
+            name: AlloyEditor.Strings.blockStyles,
+            styles: this._blockStyles
+        }), this._renderStylesItems(this._blockStyles), React.createElement(AlloyEditor.ButtonsStylesListHeader, {
+            name: AlloyEditor.Strings.inlineStyles,
+            styles: this._inlineStyles
+        }), this._renderStylesItems(this._inlineStyles), React.createElement(AlloyEditor.ButtonsStylesListHeader, {
+            name: AlloyEditor.Strings.objectStyles,
+            styles: this._objectStyles
+        }), this._renderStylesItems(this._objectStyles))
+    }
+}
+
+AlloyEditor.ButtonStylesList = AlloyEditor.EzButtonStylesList = EzButtonStylesList;
+
+const eZ = (window.eZ = window.eZ || {});
+
+eZ.ezAlloyEditor = eZ.ezAlloyEditor || {};
+eZ.ezAlloyEditor.EzButtonStylesList = EzButtonStylesList;

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslist.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-styleslist.js
@@ -3,22 +3,35 @@ import AlloyEditor from 'alloyeditor';
 import EzButtonDropdown from './ez-btn-dropdown';
 
 export default class EzButtonStylesList extends AlloyEditor.ButtonStylesList {
-
+    /**
+     * Lifecycle. Renders the UI of the list.
+     *
+     * @instance
+     * @memberof ButtonStylesList
+     * @method render
+     * @return {Object} The content which should be rendered.
+     */
     render() {
-        var e;
-        return this.props.showRemoveStylesItem && (e = React.createElement(AlloyEditor.ButtonStylesListItemRemove, {
-            editor: this.props.editor,
-            onDismiss: this.props.toggleDropdown
-        })), React.createElement(EzButtonDropdown, this.props, e, React.createElement(AlloyEditor.ButtonsStylesListHeader, {
-            name: AlloyEditor.Strings.blockStyles,
-            styles: this._blockStyles
-        }), this._renderStylesItems(this._blockStyles), React.createElement(AlloyEditor.ButtonsStylesListHeader, {
-            name: AlloyEditor.Strings.inlineStyles,
-            styles: this._inlineStyles
-        }), this._renderStylesItems(this._inlineStyles), React.createElement(AlloyEditor.ButtonsStylesListHeader, {
-            name: AlloyEditor.Strings.objectStyles,
-            styles: this._objectStyles
-        }), this._renderStylesItems(this._objectStyles))
+        let removeStylesItem;
+
+        if (this.props.showRemoveStylesItem) {
+            removeStylesItem = <AlloyEditor.ButtonStylesListItemRemove editor={this.props.editor} onDismiss={this.props.toggleDropdown} />;
+        }
+
+        return (
+            <EzButtonDropdown {...this.props}>
+                {removeStylesItem}
+
+                <AlloyEditor.ButtonsStylesListHeader name={AlloyEditor.Strings.blockStyles} styles={this._blockStyles} />
+                {this._renderStylesItems(this._blockStyles)}
+
+                <AlloyEditor.ButtonsStylesListHeader name={AlloyEditor.Strings.inlineStyles} styles={this._inlineStyles} />
+                {this._renderStylesItems(this._inlineStyles)}
+
+                <AlloyEditor.ButtonsStylesListHeader name={AlloyEditor.Strings.objectStyles} styles={this._objectStyles} />
+                {this._renderStylesItems(this._objectStyles)}
+            </EzButtonDropdown>
+        );
     }
 }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31356](https://jira.ez.no/browse/EZP-31356)
| **Bug**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |no

The focus event which is hardcoded into the AlloyEditor and attached to the styles dropdown list is not working correctly on Firefox and Safari. The reasoning for the solution was to implement `ButtonDropdown` component without this `focus` event, which does more harm than good and inject it into newly created `EzButtonStylesList` component which overwrites the default AlloyEditor's `ButtonStylesList` in order to prevent other components of being mutated.

**TODO**:
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
