### PR TITLE
EZP-30545: Provided way to define buttons in AlloyEditor toolbars

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -30,6 +30,9 @@ class RichText extends AbstractFieldTypeParser
     private const ATTRIBUTE_TYPE_STRING = 'string';
     private const ATTRIBUTE_TYPE_NUMBER = 'number';
 
+    private const TOOLBARS_NODE_KEY = 'toolbars';
+    public const TOOLBARS_SA_SETTINGS_ID = 'fieldtypes.ezrichtext.' . self::TOOLBARS_NODE_KEY;
+
     // constants common for OE custom classes and data attributes configuration
     private const ELEMENT_NODE_KEY = 'element';
     private const DEFAULT_VALUE_NODE_KEY = 'default_value';
@@ -188,6 +191,32 @@ class RichText extends AbstractFieldTypeParser
                 ->scalarPrototype()->end()
             ->end();
 
+        // RichText Toolbars configuration (defines list of Toolbars and Buttons enabled for current SiteAccess scope)
+        $nodeBuilder
+            ->arrayNode(self::TOOLBARS_NODE_KEY)
+                ->useAttributeAsKey('name')
+                ->info('List of Toolbars and Buttons enabled for current SiteAccess scope.')
+                ->prototype('array')
+                    ->children()
+                        ->arrayNode('buttons')
+                            ->useAttributeAsKey('name')
+                            ->prototype('array')
+                                ->children()
+                                    ->booleanNode('visible')
+                                        ->info('Is button visible on toolbar?')
+                                        ->defaultTrue()
+                                    ->end()
+                                    ->integerNode('priority')
+                                        ->info('Defines order in which buttons appear (255 .. -255).')
+                                        ->defaultValue(0)
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+
         $this->buildOnlineEditorConfiguration($nodeBuilder);
     }
 
@@ -236,6 +265,7 @@ class RichText extends AbstractFieldTypeParser
             $onlineEditorSettingsMap = [
                 self::CLASSES_NODE_KEY => self::CLASSES_SA_SETTINGS_ID,
                 self::ATTRIBUTES_NODE_KEY => self::ATTRIBUTES_SA_SETTINGS_ID,
+                self::TOOLBARS_NODE_KEY => self::TOOLBARS_SA_SETTINGS_ID,
             ];
             foreach ($onlineEditorSettingsMap as $key => $settingsId) {
                 if (isset($scopeSettings['fieldtypes']['ezrichtext'][$key])) {
@@ -250,6 +280,7 @@ class RichText extends AbstractFieldTypeParser
     {
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.custom_tags', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.custom_styles', $config);
+        $contextualizer->mapConfigArray(self::TOOLBARS_SA_SETTINGS_ID, $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.output_custom_xsl', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.edit_custom_xsl', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.input_custom_xsl', $config);

--- a/src/bundle/Resources/config/prepend/ezpublish.yaml
+++ b/src/bundle/Resources/config/prepend/ezpublish.yaml
@@ -12,3 +12,360 @@ system:
         fieldtypes:
             ezrichtext:
                 custom_tags: [ezyoutube, eztwitter, ezfacebook]
+                toolbars:
+                    ezyoutube:
+                        buttons:
+                            ezmoveup:
+                                priority: 80
+                            ezmovedown:
+                                priority: 70
+                            ezcustomtagedit:
+                                priority: 60
+                            ezanchor:
+                                priority: 50
+                            ezembedleft:
+                                priority: 40
+                            ezembedcenter:
+                                priority: 30
+                            ezembedright:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    eztwitter:
+                        buttons:
+                            ezmoveup:
+                                priority: 80
+                            ezmovedown:
+                                priority: 70
+                            ezcustomtagedit:
+                                priority: 60
+                            ezanchor:
+                                priority: 50
+                            ezembedleft:
+                                priority: 40
+                            ezembedcenter:
+                                priority: 30
+                            ezembedright:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    ezfacebook:
+                        buttons:
+                            ezmoveup:
+                                priority: 80
+                            ezmovedown:
+                                priority: 70
+                            ezcustomtagedit:
+                                priority: 60
+                            ezanchor:
+                                priority: 50
+                            ezembedleft:
+                                priority: 40
+                            ezembedcenter:
+                                priority: 30
+                            ezembedright:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    custom_style:
+                        buttons:
+                            ezmoveup:
+                                priority: 90
+                            ezmovedown:
+                                priority: 80
+                            ezstyles:
+                                priority: 70
+                            ezanchor:
+                                priority: 60
+                            ezblocktextalignleft:
+                                priority: 50
+                            ezblocktextaligncenter:
+                                priority: 40
+                            ezblocktextalignright:
+                                priority: 30
+                            ezblocktextalignjustify:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    embedinline:
+                        buttons:
+                            ezattributesedit:
+                                priority: 30
+                            ezembedupdate:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    embed:
+                        buttons:
+                            ezmoveup:
+                                priority: 90
+                            ezmovedown:
+                                priority: 80
+                            ezattributesedit:
+                                priority: 70
+                            ezembedupdate:
+                                priority: 60
+                            ezanchor:
+                                priority: 50
+                            ezembedleft:
+                                priority: 40
+                            ezembedcenter:
+                                priority: 30
+                            ezembedright:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    formatted:
+                        buttons:
+                            ezmoveup:
+                                priority: 60
+                            ezmovedown:
+                                priority: 50
+                            ezattributesedit:
+                                priority: 40
+                            ezstyles:
+                                priority: 30
+                            ezanchor:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    heading:
+                        buttons:
+                            ezmoveup:
+                                priority: 110
+                            ezmovedown:
+                                priority: 100
+                            ezattributesedit:
+                                priority: 90
+                            ezstyles:
+                                priority: 80
+                            ezembedinline:
+                                priority: 70
+                            ezanchor:
+                                priority: 60
+                            ezblocktextalignleft:
+                                priority: 50
+                            ezblocktextaligncenter:
+                                priority: 40
+                            ezblocktextalignright:
+                                priority: 30
+                            ezblocktextalignjustify:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    embedimagelink:
+                        buttons:
+                            ezimagelink:
+                                priority: 10
+                    embedimage:
+                        buttons:
+                            ezmoveup:
+                                priority: 110
+                            ezmovedown:
+                                priority: 100
+                            ezattributesedit:
+                                priority: 90
+                            ezimageupdate:
+                                priority: 80
+                            ezimagevariation:
+                                priority: 70
+                            ezimagelink:
+                                priority: 60
+                            ezanchor:
+                                priority: 50
+                            ezembedleft:
+                                priority: 40
+                            ezembedcenter:
+                                priority: 30
+                            ezembedright:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    link:
+                        buttons:
+                            ezlinkedit:
+                                priority: 10
+                    li:
+                        buttons:
+                            ezmoveup:
+                                priority: 60
+                            ezmovedown:
+                                priority: 50
+                            ezattributesedit:
+                                priority: 40
+                            ezembedinline:
+                                priority: 30
+                            ezanchor:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    ol:
+                        buttons:
+                            ezmoveup:
+                                priority: 60
+                            ezmovedown:
+                                priority: 50
+                            ezattributesedit:
+                                priority: 40
+                            ezembedinline:
+                                priority: 30
+                            ezanchor:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    ul:
+                        buttons:
+                            ezmoveup:
+                                priority: 60
+                            ezmovedown:
+                                priority: 50
+                            ezattributesedit:
+                                priority: 40
+                            ezembedinline:
+                                priority: 30
+                            ezanchor:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    paragraph:
+                        buttons:
+                            ezmoveup:
+                                priority: 110
+                            ezmovedown:
+                                priority: 100
+                            ezattributesedit:
+                                priority: 90
+                            ezstyles:
+                                priority: 80
+                            ezembedinline:
+                                priority: 70
+                            ezanchor:
+                                priority: 60
+                            ezblocktextalignleft:
+                                priority: 50
+                            ezblocktextaligncenter:
+                                priority: 40
+                            ezblocktextalignright:
+                                priority: 30
+                            ezblocktextalignjustify:
+                                priority: 20
+                            ezblockremove:
+                                priority: 10
+                    td:
+                        buttons:
+                            ezmoveup:
+                                priority: 100
+                            ezmovedown:
+                                priority: 90
+                            ezattributesedit:
+                                priority: 80
+                            tableHeading:
+                                priority: 70
+                            ezembedinline:
+                                priority: 60
+                            ezanchor:
+                                priority: 50
+                            eztablerow:
+                                priority: 40
+                            eztablecolumn:
+                                priority: 30
+                            eztablecell:
+                                priority: 20
+                            eztableremove:
+                                priority: 10
+                    th:
+                        buttons:
+                            ezmoveup:
+                                priority: 100
+                            ezmovedown:
+                                priority: 90
+                            ezattributesedit:
+                                priority: 80
+                            tableHeading:
+                                priority: 70
+                            ezembedinline:
+                                priority: 60
+                            ezanchor:
+                                priority: 50
+                            eztablerow:
+                                priority: 40
+                            eztablecolumn:
+                                priority: 30
+                            eztablecell:
+                                priority: 20
+                            eztableremove:
+                                priority: 10
+                    tr:
+                        buttons:
+                            ezmoveup:
+                                priority: 70
+                            ezmovedown:
+                                priority: 60
+                            ezattributesedit:
+                                priority: 50
+                            tableHeading:
+                                priority: 40
+                            ezembedinline:
+                                priority: 30
+                            ezanchor:
+                                priority: 20
+                            eztableremove:
+                                priority: 10
+                    table:
+                        buttons:
+                            ezmoveup:
+                                priority: 70
+                            ezmovedown:
+                                priority: 60
+                            ezattributesedit:
+                                priority: 50
+                            tableHeading:
+                                priority: 40
+                            ezembedinline:
+                                priority: 30
+                            ezanchor:
+                                priority: 20
+                            eztableremove:
+                                priority: 10
+                    text:
+                        buttons:
+                            ezstyles:
+                                priority: 90
+                            ezbold:
+                                priority: 80
+                            ezitalic:
+                                priority: 70
+                            ezunderline:
+                                priority: 60
+                            ezsubscript:
+                                priority: 50
+                            ezsuperscript:
+                                priority: 40
+                            ezquote:
+                                priority: 30
+                            ezstrike:
+                                priority: 20
+                            ezlink:
+                                priority: 10
+                    ezadd:
+                        buttons:
+                            ezheading:
+                                priority: 100
+                            ezparagraph:
+                                priority: 90
+                            ezunorderedlist:
+                                priority: 80
+                            ezorderedlist:
+                                priority: 70
+                            ezimage:
+                                priority: 60
+                            ezembed:
+                                priority: 50
+                            eztable:
+                                priority: 40
+                            ezyoutube:
+                                priority: 30
+                            eztwitter:
+                                priority: 20
+                            ezfacebook:
+                                priority: 10

--- a/src/bundle/Resources/public/js/OnlineEditor/core/base-richtext.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/core/base-richtext.js
@@ -9,16 +9,6 @@
             this.xhtmlNamespace = 'http://www.w3.org/1999/xhtml';
             this.customTags = Object.keys(eZ.richText.customTags).filter((key) => !eZ.richText.customTags[key].isInline);
             this.inlineCustomTags = Object.keys(eZ.richText.customTags).filter((key) => eZ.richText.customTags[key].isInline);
-            this.alloyEditorExtraButtons = {
-                ezadd: [],
-                link: [],
-                text: [],
-                table: [],
-                tr: [],
-                td: [],
-                th: [],
-                ...eZ.richText.alloyEditor.extraButtons,
-            };
             this.attributes = global.eZ.richText.alloyEditor.attributes;
             this.classes = global.eZ.richText.alloyEditor.classes;
             this.customTagsToolbars = this.customTags.map((customTag) => {
@@ -27,7 +17,6 @@
                 return new eZ.ezAlloyEditor.ezCustomTagConfig({
                     name: customTag,
                     alloyEditor: alloyEditorConfig,
-                    extraButtons: this.alloyEditorExtraButtons,
                 });
             });
             this.inlineCustomTagsToolbars = this.inlineCustomTags.map((customTag) => {
@@ -36,7 +25,6 @@
                 return new eZ.ezAlloyEditor.ezInlineCustomTagConfig({
                     name: customTag,
                     alloyEditor: alloyEditorConfig,
-                    extraButtons: this.alloyEditorExtraButtons,
                 });
             });
             this.customStylesConfigurations = Object.entries(eZ.richText.customStyles).map(([customStyleName, customStyleConfig]) => {
@@ -189,24 +177,14 @@
         }
 
         init(container) {
-            const toolbarProps = { extraButtons: this.alloyEditorExtraButtons, attributes: this.attributes, classes: this.classes };
+            const toolbarProps = { attributes: this.attributes, classes: this.classes };
             const customSelections = this.customStyleSelections.map((Selection) => {
                 return new Selection(toolbarProps);
             });
             const alloyEditor = AlloyEditor.editable(container.getAttribute('id'), {
                 toolbars: {
                     ezadd: {
-                        buttons: [
-                            'ezheading',
-                            'ezparagraph',
-                            'ezunorderedlist',
-                            'ezorderedlist',
-                            'ezimage',
-                            'ezembed',
-                            'eztable',
-                            ...this.customTags,
-                            ...this.alloyEditorExtraButtons['ezadd'],
-                        ],
+                        buttons: eZ.richText.alloyEditor.toolbars.ezadd.buttons,
                         tabIndex: 2,
                     },
                     styles: {

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-buttons.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-buttons.js
@@ -1,0 +1,53 @@
+import AlloyEditor from 'alloyeditor';
+
+export default class EzConfigButtonsBase {
+    getButtons(config) {
+        const toolbarConfig = window.eZ.richText.alloyEditor.toolbars[this.name];
+
+        if (!toolbarConfig) {
+            return [];
+        }
+
+        const buttons = [...toolbarConfig.buttons];
+        const attributesEditIndex = buttons.indexOf('ezattributesedit');
+        const stylesIndex = buttons.indexOf('ezstyles');
+
+        if (attributesEditIndex > -1) {
+            buttons[attributesEditIndex] = this.getEditAttributesButton(config);
+        }
+
+        if (stylesIndex > -1) {
+            buttons[stylesIndex] = this.getStyles(config.customStyles);
+        }
+
+        return buttons;
+    }
+
+    getStyles(customStyles = []) {
+        const headingLabel = Translator.trans(/*@Desc("Heading")*/ 'toolbar_config_base.heading_label', {}, 'alloy_editor');
+        const paragraphLabel = Translator.trans(/*@Desc("Paragraph")*/ 'toolbar_config_base.paragraph_label', {}, 'alloy_editor');
+        const formattedLabel = Translator.trans(/*@Desc("Formatted")*/ 'toolbar_config_base.formatted_label', {}, 'alloy_editor');
+
+        return {
+            name: 'styles',
+            cfg: {
+                showRemoveStylesItem: false,
+                styles: [
+                    { name: `${headingLabel} 1`, style: { element: 'h1' } },
+                    { name: `${headingLabel} 2`, style: { element: 'h2' } },
+                    { name: `${headingLabel} 3`, style: { element: 'h3' } },
+                    { name: `${headingLabel} 4`, style: { element: 'h4' } },
+                    { name: `${headingLabel} 5`, style: { element: 'h5' } },
+                    { name: `${headingLabel} 6`, style: { element: 'h6' } },
+                    { name: paragraphLabel, style: { element: 'p' } },
+                    { name: formattedLabel, style: { element: 'pre' } },
+                    ...customStyles,
+                ],
+            },
+        };
+    }
+
+    getEditAttributesButton(config) {
+        return config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '';
+    }
+}

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-list.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-list.js
@@ -5,9 +5,7 @@ export default class EzListBaseConfig extends EzConfigBase {
         super(config);
 
         this.name = this.getConfigName();
-        this.buttons = ['ezmoveup', 'ezmovedown', this.getEditAttributesButton(config), 'ezembedinline', 'ezanchor', 'ezblockremove'];
-
-        this.addExtraButtons(config.extraButtons);
+        this.buttons = this.getButtons(config);
     }
 
     getConfigName() {

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
@@ -1,21 +1,12 @@
 import AlloyEditor from 'alloyeditor';
+import EzConfigButtonsBase from './base-buttons';
 
-export default class EzConfigTableBase {
+export default class EzConfigTableBase extends EzConfigButtonsBase {
     constructor(config) {
+        super(config);
+
         this.name = this.getConfigName();
-
-        const editAttributesButton = config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '';
-
-        this.buttons = [
-            'ezmoveup',
-            'ezmovedown',
-            editAttributesButton,
-            'tableHeading',
-            'ezembedinline',
-            'ezanchor',
-            'eztableremove',
-            ...config.extraButtons[this.name],
-        ];
+        this.buttons = this.getButtons(config);
 
         this.getArrowBoxClasses = AlloyEditor.SelectionGetArrowBoxClasses.table;
         this.setPosition = AlloyEditor.SelectionSetPosition.table;

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base.js
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom';
+import EzConfigButtonsBase from './base-buttons';
 
-export default class EzConfigBase {
+export default class EzConfigBase extends EzConfigButtonsBase {
     static outlineTotalWidth(block) {
         let outlineOffset = parseInt(block.getComputedStyle('outline-offset'), 10);
         const outlineWidth = parseInt(block.getComputedStyle('outline-width'), 10);
@@ -91,40 +92,6 @@ export default class EzConfigBase {
         }
 
         return block;
-    }
-
-    getStyles(customStyles = []) {
-        const headingLabel = Translator.trans(/*@Desc("Heading")*/ 'toolbar_config_base.heading_label', {}, 'alloy_editor');
-        const paragraphLabel = Translator.trans(/*@Desc("Paragraph")*/ 'toolbar_config_base.paragraph_label', {}, 'alloy_editor');
-        const formattedLabel = Translator.trans(/*@Desc("Formatted")*/ 'toolbar_config_base.formatted_label', {}, 'alloy_editor');
-
-        return {
-            name: 'styles',
-            cfg: {
-                showRemoveStylesItem: false,
-                styles: [
-                    { name: `${headingLabel} 1`, style: { element: 'h1' } },
-                    { name: `${headingLabel} 2`, style: { element: 'h2' } },
-                    { name: `${headingLabel} 3`, style: { element: 'h3' } },
-                    { name: `${headingLabel} 4`, style: { element: 'h4' } },
-                    { name: `${headingLabel} 5`, style: { element: 'h5' } },
-                    { name: `${headingLabel} 6`, style: { element: 'h6' } },
-                    { name: paragraphLabel, style: { element: 'p' } },
-                    { name: formattedLabel, style: { element: 'pre' } },
-                    ...customStyles,
-                ],
-            },
-        };
-    }
-
-    getEditAttributesButton(config) {
-        return config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '';
-    }
-
-    addExtraButtons(extraButtons = {}) {
-        if (extraButtons[this.name]) {
-            this.buttons = [...this.buttons, ...extraButtons[this.name]];
-        }
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-custom-style.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-custom-style.js
@@ -4,20 +4,8 @@ export default class EzCustomStyleConfig extends EzConfigBase {
     constructor(config) {
         super(config);
 
-        this.name = 'custom-style';
-        this.buttons = [
-            'ezmoveup',
-            'ezmovedown',
-            this.getStyles(config.customStyles),
-            'ezanchor',
-            'ezblocktextalignleft',
-            'ezblocktextaligncenter',
-            'ezblocktextalignright',
-            'ezblocktextalignjustify',
-            'ezblockremove',
-        ];
-
-        this.addExtraButtons(config.extraButtons);
+        this.name = 'custom_style';
+        this.buttons = this.getButtons(config);
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-custom-tag.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-custom-tag.js
@@ -4,24 +4,16 @@ export default class EzCustomTagConfig extends EzConfigBase {
     constructor(config) {
         super(config);
 
-        const editButton = !!config.alloyEditor.attributes ? `${config.name}edit` : '';
-        const defaultButtons = [
-            'ezmoveup',
-            'ezmovedown',
-            editButton,
-            'ezanchor',
-            'ezembedleft',
-            'ezembedcenter',
-            'ezembedright',
-            'ezblockremove',
-        ];
-        const customButtons = config.alloyEditor.toolbarButtons;
-        const buttons = customButtons && customButtons.length ? customButtons : defaultButtons;
-
         this.name = config.name;
-        this.buttons = buttons;
 
-        this.addExtraButtons(config.extraButtons);
+        const buttons = this.getButtons(config);
+        const customTagEditIndex = buttons.indexOf('ezcustomtagedit');
+
+        if (customTagEditIndex > -1) {
+            buttons[customTagEditIndex] = !!config.alloyEditor.attributes ? `${config.name}edit` : '';
+        }
+
+        this.buttons = buttons;
 
         this.test = this.test.bind(this);
     }

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-embed-inline.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-embed-inline.js
@@ -7,9 +7,7 @@ export default class EzEmbedInlineConfig extends EzConfigBase {
         super(config);
 
         this.name = 'embedinline';
-        this.buttons = [this.getEditAttributesButton(config), 'ezembedupdate', 'ezblockremove'];
-
-        this.addExtraButtons(config.extraButtons);
+        this.buttons = this.getButtons(config);
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-embed.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-embed.js
@@ -5,19 +5,7 @@ export default class EzEmbedConfig extends EzConfigBase {
         super(config);
 
         this.name = 'embed';
-        this.buttons = [
-            'ezmoveup',
-            'ezmovedown',
-            this.getEditAttributesButton(config),
-            'ezembedupdate',
-            'ezanchor',
-            'ezembedleft',
-            'ezembedcenter',
-            'ezembedright',
-            'ezblockremove',
-        ];
-
-        this.addExtraButtons(config.extraButtons);
+        this.buttons = this.getButtons(config);
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-formatted.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-formatted.js
@@ -5,16 +5,7 @@ export default class EzFormattedConfig extends EzConfigBase {
         super(config);
 
         this.name = 'formatted';
-        this.buttons = [
-            'ezmoveup',
-            'ezmovedown',
-            this.getEditAttributesButton(config),
-            this.getStyles(config.customStyles),
-            'ezanchor',
-            'ezblockremove',
-        ];
-
-        this.addExtraButtons(config.extraButtons);
+        this.buttons = this.getButtons(config);
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-heading.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-heading.js
@@ -5,21 +5,7 @@ export default class EzHeadingConfig extends EzConfigFixedBase {
         super(config);
 
         this.name = 'heading';
-        this.buttons = [
-            'ezmoveup',
-            'ezmovedown',
-            this.getEditAttributesButton(config),
-            this.getStyles(config.customStyles),
-            'ezembedinline',
-            'ezanchor',
-            'ezblocktextalignleft',
-            'ezblocktextaligncenter',
-            'ezblocktextalignright',
-            'ezblocktextalignjustify',
-            'ezblockremove',
-        ];
-
-        this.addExtraButtons(config.extraButtons);
+        this.buttons = this.getButtons(config);
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-image-link.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-image-link.js
@@ -5,9 +5,7 @@ export default class EzEmbedImageLinkConfig extends EzConfigBase {
         super(config);
 
         this.name = 'embedimagelink';
-        this.buttons = ['ezimagelink'];
-
-        this.addExtraButtons(config.extraButtons);
+        this.buttons = this.getButtons(config);
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-image.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-image.js
@@ -5,21 +5,7 @@ export default class EzEmbedImageConfig extends EzConfigBase {
         super(config);
 
         this.name = 'embedimage';
-        this.buttons = [
-            'ezmoveup',
-            'ezmovedown',
-            this.getEditAttributesButton(config),
-            'ezimageupdate',
-            'ezimagevariation',
-            'ezimagelink',
-            'ezanchor',
-            'ezembedleft',
-            'ezembedcenter',
-            'ezembedright',
-            'ezblockremove',
-        ];
-
-        this.addExtraButtons(config.extraButtons);
+        this.buttons = this.getButtons(config);
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-inline-custom-tag.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-inline-custom-tag.js
@@ -4,15 +4,16 @@ export default class EzInlineCustomTagConfig extends EzConfigBase {
     constructor(config) {
         super(config);
 
-        const editButton = !!config.alloyEditor.attributes ? `${config.name}edit` : '';
-        const defaultButtons = [editButton, 'ezblockremove'];
-        const customButtons = config.alloyEditor.toolbarButtons;
-        const buttons = customButtons && customButtons.length ? customButtons : defaultButtons;
-
         this.name = config.name;
-        this.buttons = buttons;
 
-        this.addExtraButtons(config.extraButtons);
+        const buttons = this.getButtons(config);
+        const customTagEditIndex = buttons.indexOf('ezcustomtagedit');
+
+        if (customTagEditIndex > -1) {
+            buttons[customTagEditIndex] = !!config.alloyEditor.attributes ? `${config.name}edit` : '';
+        }
+
+        this.buttons = buttons;
 
         this.test = this.test.bind(this);
     }

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-link.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-link.js
@@ -1,9 +1,12 @@
 import AlloyEditor from 'alloyeditor';
+import EzConfigButtonsBase from './base-buttons';
 
-export default class EzLinkConfig {
+export default class EzLinkConfig extends EzConfigButtonsBase {
     constructor(config) {
+        super(config);
+
         this.name = 'link';
-        this.buttons = ['ezlinkedit', ...config.extraButtons[this.name]];
+        this.buttons = this.getButtons(config);
 
         this.test = AlloyEditor.SelectionTest.link;
     }

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-paragraph.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-paragraph.js
@@ -5,21 +5,7 @@ export default class EzParagraphConfig extends EzConfigFixedBase {
         super(config);
 
         this.name = 'paragraph';
-        this.buttons = [
-            'ezmoveup',
-            'ezmovedown',
-            this.getEditAttributesButton(config),
-            this.getStyles(config.customStyles),
-            'ezembedinline',
-            'ezanchor',
-            'ezblocktextalignleft',
-            'ezblocktextaligncenter',
-            'ezblocktextalignright',
-            'ezblocktextalignjustify',
-            'ezblockremove',
-        ];
-
-        this.addExtraButtons(config.extraButtons);
+        this.buttons = this.getButtons(config);
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-table-cell.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-table-cell.js
@@ -4,21 +4,7 @@ export default class EzTableCellConfig extends EzConfigTableBase {
     constructor(config) {
         super(config);
 
-        const editAttributesButton = config.attributes[this.name] || config.classes[this.name] ? `${this.name}edit` : '';
-
-        this.buttons = [
-            'ezmoveup',
-            'ezmovedown',
-            editAttributesButton,
-            'tableHeading',
-            'ezembedinline',
-            'ezanchor',
-            'eztablerow',
-            'eztablecolumn',
-            'eztablecell',
-            'eztableremove',
-            ...config.extraButtons[this.name],
-        ];
+        this.buttons = this.getButtons(config);
     }
 
     getConfigName() {

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-text.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/ez-text.js
@@ -1,21 +1,12 @@
 import AlloyEditor from 'alloyeditor';
+import EzConfigButtonsBase from './base-buttons';
 
-export default class EzTextConfig {
+export default class EzTextConfig extends EzConfigButtonsBase {
     constructor(config) {
+        super(config);
+
         this.name = 'text';
-        this.buttons = [
-            this.getStyles(config.customStyles),
-            'ezbold',
-            'ezitalic',
-            'ezunderline',
-            'ezsubscript',
-            'ezsuperscript',
-            'ezquote',
-            'ezstrike',
-            'ezlink',
-            ...config.inlineCustomTags,
-            ...config.extraButtons[this.name],
-        ];
+        this.buttons = this.getButtons(config);
 
         this.test = AlloyEditor.SelectionTest.text;
     }

--- a/src/lib/Configuration/Provider/AlloyEditor.php
+++ b/src/lib/Configuration/Provider/AlloyEditor.php
@@ -51,10 +51,43 @@ final class AlloyEditor implements Provider
     {
         return [
             'extraPlugins' => $this->getExtraPlugins(),
-            'extraButtons' => $this->getExtraButtons(),
+            'toolbars' => $this->getToolbars(),
             'classes' => $this->getCssClasses(),
             'attributes' => $this->getDataAttributes(),
         ];
+    }
+
+    /**
+     * @return array Toolbars configuration
+     */
+    private function getToolbars(): array
+    {
+        $toolbarsConfiguration = $this->getSiteAccessConfigArray(RichText::TOOLBARS_SA_SETTINGS_ID);
+        $toolbars = [];
+
+        foreach ($toolbarsConfiguration as $toolbar => $configuration) {
+            $toolbars[$toolbar] = [
+                'buttons' => $this->getToolbarButtons($configuration['buttons'] ?? []),
+            ];
+        }
+
+        return $toolbars;
+    }
+
+    /**
+     * @return string[] List of visible buttons
+     */
+    private function getToolbarButtons(array $buttons): array
+    {
+        $buttons = array_filter($buttons, static function (array $value): bool {
+            return $value['visible'];
+        });
+
+        uasort($buttons, static function (array $a, array $b): int {
+            return $b['priority'] <=> $a['priority'];
+        });
+
+        return array_keys($buttons);
     }
 
     /**
@@ -63,27 +96,6 @@ final class AlloyEditor implements Provider
     private function getExtraPlugins(): array
     {
         return $this->alloyEditorConfiguration['extra_plugins'] ?? [];
-    }
-
-    /**
-     * @deprecated 3.0.0 The alternative and more flexible solution will be introduced.
-     * @deprecated 3.0.0 So you will need to update Online Editor Extra Buttons as part of eZ Platform 3.x upgrade.
-     *
-     * @return array Custom buttons
-     */
-    private function getExtraButtons(): array
-    {
-        if (empty($this->alloyEditorConfiguration['extra_buttons'])) {
-            return [];
-        }
-
-        @trigger_error(
-            '"ezrichtext.alloy_editor.extra_buttons" is deprecated since v2.5.1. ' .
-            'There will be new and more flexible solution to manage buttons in Online Editor in 3.0.0',
-            E_USER_DEPRECATED
-        );
-
-        return $this->alloyEditorConfiguration['extra_buttons'];
     }
 
     /**

--- a/tests/lib/Configuration/Provider/AlloyEditorTest.php
+++ b/tests/lib/Configuration/Provider/AlloyEditorTest.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
 
 namespace EzSystems\Tests\EzPlatformRichText\Configuration\Provider;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\EzPlatformRichText\Configuration\Provider\AlloyEditor;
 use EzSystems\EzPlatformRichText\Configuration\UI\Mapper\OnlineEditorConfigMapper;
 use EzSystems\EzPlatformRichText\SPI\Configuration\Provider;
+use EzSystems\EzPlatformRichTextBundle\DependencyInjection\Configuration\Parser\FieldType\RichText;
 
 class AlloyEditorTest extends BaseProviderTestCase
 {
@@ -24,14 +26,13 @@ class AlloyEditorTest extends BaseProviderTestCase
         $this->mapper = $this->createMock(OnlineEditorConfigMapper::class);
     }
 
-    public function createProvider(): Provider
+    public function createProvider(ConfigResolverInterface $configResolver = null): Provider
     {
         return new AlloyEditor(
             [
                 'extra_plugins' => ['plugin1', 'plugin2'],
-                'extra_buttons' => ['button1', 'button2'],
             ],
-            $this->configResolver,
+            $configResolver ?? $this->configResolver,
             $this->mapper
         );
     }
@@ -68,11 +69,154 @@ class AlloyEditorTest extends BaseProviderTestCase
         self::assertEquals(
             [
                 'extraPlugins' => ['plugin1', 'plugin2'],
-                'extraButtons' => ['button1', 'button2'],
+                'toolbars' => [],
                 'classes' => ['class1', 'class2'],
                 'attributes' => ['attr1', 'attr2'],
             ],
             $provider->getConfiguration()
         );
+    }
+
+    public function testToolbarConfiguration(): void
+    {
+        $configResolver = $this->createMock(ConfigResolverInterface::class);
+
+        $configResolver
+            ->method('hasParameter')
+            ->willReturn(true);
+
+        $configResolver
+            ->method('getParameter')
+            ->willReturnCallback($this->buildTestToolbarReturnCallback([
+                'test_toolbar' => [
+                    'buttons' => [
+                        'test_button' => [
+                            'visible' => true,
+                            'priority' => 0,
+                        ],
+                    ],
+                ],
+            ]));
+
+        $provider = $this->createProvider($configResolver);
+
+        self::assertEquals(
+            [
+                'extraPlugins' => ['plugin1', 'plugin2'],
+                'toolbars' => [
+                    'test_toolbar' => [
+                        'buttons' => ['test_button'],
+                    ],
+                ],
+                'classes' => [],
+                'attributes' => [],
+            ],
+            $provider->getConfiguration()
+        );
+    }
+
+    public function testToolbarConfigurationPriority(): void
+    {
+        $configResolver = $this->createMock(ConfigResolverInterface::class);
+
+        $configResolver
+            ->method('hasParameter')
+            ->willReturn(true);
+
+        $configResolver
+            ->method('getParameter')
+            ->willReturnCallback($this->buildTestToolbarReturnCallback([
+                'test_toolbar' => [
+                    'buttons' => [
+                        'test_button_last' => [
+                            'visible' => true,
+                            'priority' => -100,
+                        ],
+                        'test_button_first' => [
+                            'visible' => true,
+                            'priority' => 100,
+                        ],
+                        'test_button_middle' => [
+                            'visible' => true,
+                            'priority' => 0,
+                        ],
+                    ],
+                ],
+            ]));
+
+        $provider = $this->createProvider($configResolver);
+
+        self::assertEquals(
+            [
+                'extraPlugins' => ['plugin1', 'plugin2'],
+                'toolbars' => [
+                    'test_toolbar' => [
+                        'buttons' => ['test_button_first', 'test_button_middle', 'test_button_last'],
+                    ],
+                ],
+                'classes' => [],
+                'attributes' => [],
+            ],
+            $provider->getConfiguration()
+        );
+    }
+
+    public function testToolbarConfigurationVisibility(): void
+    {
+        $configResolver = $this->createMock(ConfigResolverInterface::class);
+
+        $configResolver
+            ->method('hasParameter')
+            ->willReturn(true);
+
+        $configResolver
+            ->method('getParameter')
+            ->willReturnCallback($this->buildTestToolbarReturnCallback([
+                'test_toolbar' => [
+                    'buttons' => [
+                        'test_button_last' => [
+                            'visible' => true,
+                            'priority' => -100,
+                        ],
+                        'test_button_first' => [
+                            'visible' => true,
+                            'priority' => 100,
+                        ],
+                        'test_button_middle' => [
+                            'visible' => false,
+                            'priority' => 0,
+                        ],
+                    ],
+                ],
+            ]));
+
+        $provider = $this->createProvider($configResolver);
+
+        self::assertEquals(
+            [
+                'extraPlugins' => ['plugin1', 'plugin2'],
+                'toolbars' => [
+                    'test_toolbar' => [
+                        'buttons' => ['test_button_first', 'test_button_last'],
+                    ],
+                ],
+                'classes' => [],
+                'attributes' => [],
+            ],
+            $provider->getConfiguration()
+        );
+    }
+
+    private function buildTestToolbarReturnCallback(array $buttonsConfig): callable
+    {
+        return static function (string $paramName) use ($buttonsConfig): ?array {
+            $map = [
+                RichText::TOOLBARS_SA_SETTINGS_ID => $buttonsConfig,
+                RichText::CLASSES_SA_SETTINGS_ID => [],
+                RichText::ATTRIBUTES_SA_SETTINGS_ID => [],
+            ];
+
+            return $map[$paramName] ?? null;
+        };
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30545](https://jira.ez.no/browse/EZP-30545)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

Example configuration:

```yaml
system:
    admin_group:
        fieldtypes:
            ezrichtext:
                toolbars:
                    my_toolbar:
                        buttons:
                            my_last_button:
                                priority: -100
                            hidden_button:
                                visible: false
                            first_button:
                                priority: 50
                            button_with_defaults:
                                priority: 0
                                visible: true
```

**For QA**
All toolbars should be in the same place and with the same buttons by default
We need to test if it is possible to change the order of buttons in toolbars (by priority) and hide some buttons (by visible), also we need to test if it is possible to add new buttons into the toolbar by the yml file.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
