### PR TITLE
EZP-31118: Added missing int casting in the Converter\Link::convert

### DIFF
--- a/src/lib/eZ/RichText/Converter/Link.php
+++ b/src/lib/eZ/RichText/Converter/Link.php
@@ -77,7 +77,7 @@ class Link implements Converter
 
             if ($scheme === 'ezcontent://') {
                 try {
-                    $contentInfo = $this->contentService->loadContentInfo($id);
+                    $contentInfo = $this->contentService->loadContentInfo((int)$id);
                     $location = $this->locationService->loadLocation($contentInfo->mainLocationId);
                     $hrefResolved = $this->urlAliasRouter->generate($location) . $fragment;
                 } catch (APINotFoundException $e) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31118](https://jira.ez.no/browse/EZP-31118)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Fixed failing Travis build:
https://travis-ci.org/github/ezsystems/ezplatform-richtext/jobs/662976234. 

ID's extracted by regexp form internal URL should be cased to int in `EzSystems\EzPlatformRichText\eZ\RichText\Converter\Link::convert`

Note for reviewers: in the near future this logic will be completly refactored as part of the https://github.com/ezsystems/ezplatform-richtext/pull/112

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
