### PR TITLE
EZEE-3030: Links containing 'ezlocation` or 'ezcontent' keywords break RTE validation on paste

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/core/base-richtext.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/core/base-richtext.js
@@ -389,17 +389,31 @@
             const links = container.querySelectorAll('a');
             const anchorPrefix = '#';
             const protocolPrefix = 'http://';
+            const restrictedKeywords = ['ezcontent', 'ezlocation'];
 
             links.forEach((link) => {
                 const href = link.getAttribute('href');
                 const protocolPattern = /^https?:\/\//i;
+                const protocolHref = protocolPrefix.concat(href);
 
-                if (href && href.indexOf(anchorPrefix) !== 0 && !protocolPattern.test(href)) {
-                    const protocolHref = protocolPrefix.concat(href);
-
-                    link.setAttribute('href', protocolHref);
-                    link.setAttribute('data-cke-saved-href', protocolHref);
+                if (!href) {
+                    return;
                 }
+
+                if (href.indexOf(anchorPrefix) === 0) {
+                    return;
+                }
+
+                if (protocolPattern.test(href)) {
+                    return;
+                }
+
+                if (restrictedKeywords.some((keyword) => href.includes(keyword))) {
+                    return;
+                }
+
+                link.setAttribute('href', protocolHref);
+                link.setAttribute('data-cke-saved-href', protocolHref);
             });
         }
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-3030](https://jira.ez.no/browse/EZEE-3030)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This is a followup for https://github.com/ezsystems/ezplatform-admin-ui/pull/1283 targeting eZ Platform 3.0 (`master`).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
