### PR TITLE
EZP-31007: Replaced ezpublish-kernel with ezplatform-kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 This Bundle provides RichText (`ezrichtext`) Field Type for eZ Platform 2.4 and higher.
 It is a Field Type for supporting rich formatted text stored in a structured XML format.
 
-This package overrides services provided by the `eZ\Publish\Core\FieldType\RichText` namespace of
-`ezsystems/ezpublish-kernel` package.
-
 This Field Type succeeds the former [XMLText](https://github.com/ezsystems/ezplatform-xmltext-fieldtype)
 Field Type found in eZ Publish 5.x and before.
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/translation": "^5.0",
         "symfony/translation-contracts": "^2.0",
         "twig/twig": "^3.0",
-        "ezsystems/ezpublish-kernel": "^8.0@dev",
+        "ezsystems/ezplatform-kernel": "^1.0@dev",
         "ezsystems/ezplatform-content-forms": "^1.0@dev",
         "ezsystems/ezplatform-rest": "^1.0@dev"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "ezsystems/ezplatform-rest": "^1.0@dev"
     },
     "require-dev": {
+        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "phpunit/phpunit": "^8.5",
         "symfony/finder": "^5.0",
         "matthiasnoback/symfony-config-test": "^4.1",

--- a/tests/integration/eZ/API/SetupFactory/CoreSetupFactoryTrait.php
+++ b/tests/integration/eZ/API/SetupFactory/CoreSetupFactoryTrait.php
@@ -19,9 +19,9 @@ use Symfony\Component\DependencyInjection\Reference;
 trait CoreSetupFactoryTrait
 {
     /**
-     * Load ezpublish-kernel settings and setup container.
+     * Load eZ Platform Kernel settings and setup container.
      *
-     * @todo refactor ezpublish-kernel SetupFactory to include that setup w/o relying on config.php
+     * @todo refactor ezplatform-kernel SetupFactory to include that setup w/o relying on config.php
      *
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $containerBuilder
      *
@@ -30,9 +30,9 @@ trait CoreSetupFactoryTrait
     protected function loadCoreSettings(ContainerBuilder $containerBuilder)
     {
         // @todo refactor when refactoring kernel SetupFactory to avoid hardcoding package path
-        $kernelRootDir = realpath(__DIR__ . '/../../../../../vendor/ezsystems/ezpublish-kernel');
+        $kernelRootDir = realpath(__DIR__ . '/../../../../../vendor/ezsystems/ezplatform-kernel');
         if (false === $kernelRootDir) {
-            throw new RuntimeException('Unable to find the ezpublish-kernel package directory');
+            throw new RuntimeException('Unable to find the ezplatform-kernel package directory');
         }
         $settingsPath = "{$kernelRootDir}/eZ/Publish/Core/settings";
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31007](https://jira.ez.no/browse/EZP-31007)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR replaces `ezpublish-kernel` with `ezplatform-kernel` and fixes dependency issues blocking package installation (due to Composer minimum stability requirements):

- `ezsystems/doctrine-dbal-schema:^1.0@dev` is required  by `ezplatform-kernel:^1.0@dev`
- other packages are required by `ezsystems/ezplatform-admin-ui:^2.0@dev`

#### TODO
- [ ] Wait for Travis