### PR TITLE
EZP-31499: Fixed generating routes for links in DocBook

### DIFF
--- a/src/lib/eZ/RichText/Converter/Link.php
+++ b/src/lib/eZ/RichText/Converter/Link.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\EzPlatformRichText\eZ\RichText\Converter;
 
+use eZ\Publish\API\Repository\Values\Content\Location;
 use EzSystems\EzPlatformRichText\eZ\RichText\Converter;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
@@ -79,7 +80,7 @@ class Link implements Converter
                 try {
                     $contentInfo = $this->contentService->loadContentInfo((int) $id);
                     $location = $this->locationService->loadLocation($contentInfo->mainLocationId);
-                    $hrefResolved = $this->urlAliasRouter->generate($location) . $fragment;
+                    $hrefResolved = $this->generateUrlAliasForLocation($location, $fragment);
                 } catch (APINotFoundException $e) {
                     if ($this->logger) {
                         $this->logger->warning(
@@ -98,7 +99,7 @@ class Link implements Converter
             } elseif ($scheme === 'ezlocation://') {
                 try {
                     $location = $this->locationService->loadLocation((int) $id);
-                    $hrefResolved = $this->urlAliasRouter->generate($location) . $fragment;
+                    $hrefResolved = $this->generateUrlAliasForLocation($location, $fragment);
                 } catch (APINotFoundException $e) {
                     if ($this->logger) {
                         $this->logger->warning(
@@ -132,5 +133,15 @@ class Link implements Converter
         }
 
         return $document;
+    }
+
+    private function generateUrlAliasForLocation(Location $location, string $fragment): string
+    {
+        $urlAlias = $this->urlAliasRouter->generate(
+            UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            ['location' => $location]
+        );
+
+        return $urlAlias . $fragment;
     }
 }

--- a/tests/lib/eZ/RichText/Converter/AggregateTest.php
+++ b/tests/lib/eZ/RichText/Converter/AggregateTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace EzSystems\Tests\EzPlatformRichText\eZ\RichText\Converter;
 
+use DOMDocument;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
@@ -20,18 +21,13 @@ use PHPUnit\Framework\TestCase;
 class AggregateTest extends TestCase
 {
     /**
-     * @param $input
-     * @param $expectedWarningMessage
-     *
      * @dataProvider providerConvertWithLinkInCustomTag
      *
      * @see https://jira.ez.no/browse/EZP-30166
      */
-    public function testConvertWithLinkInCustomTag(
-        $input,
-        $expectedOutput
-    ) {
-        $xmlDocument = new \DOMDocument();
+    public function testConvertWithLinkInCustomTag(string $input, string $expectedOutput): void
+    {
+        $xmlDocument = new DOMDocument();
         $xmlDocument->loadXML($input);
 
         $locationService = $this->createMock(LocationService::class);
@@ -55,7 +51,7 @@ class AggregateTest extends TestCase
         $aggregate = new Aggregate([$templateConverter, $linkConverter]);
         $output = $aggregate->convert($xmlDocument);
 
-        $expectedOutputDocument = new \DOMDocument();
+        $expectedOutputDocument = new DOMDocument();
         $expectedOutputDocument->loadXML($expectedOutput);
         $this->assertEquals($expectedOutputDocument, $output, 'Xml is not converted as expected');
     }

--- a/tests/lib/eZ/RichText/Converter/LinkTest.php
+++ b/tests/lib/eZ/RichText/Converter/LinkTest.php
@@ -226,10 +226,7 @@ class LinkTest extends TestCase
 
         $urlAliasRouter->expects($this->once())
             ->method('generate')
-            ->with(
-                $this->equalTo(UrlAliasRouter::URL_ALIAS_ROUTE_NAME),
-                $this->equalTo(['location' => $location])
-            )
+            ->with(UrlAliasRouter::URL_ALIAS_ROUTE_NAME, ['location' => $location])
             ->willReturn($urlResolved);
 
         $converter = new Link($locationService, $contentService, $urlAliasRouter);
@@ -444,10 +441,7 @@ class LinkTest extends TestCase
 
         $urlAliasRouter->expects($this->once())
             ->method('generate')
-            ->with(
-                $this->equalTo(UrlAliasRouter::URL_ALIAS_ROUTE_NAME),
-                $this->equalTo(['location' => $location])
-            )
+            ->with(UrlAliasRouter::URL_ALIAS_ROUTE_NAME, ['location' => $location])
             ->willReturn($urlResolved);
 
         $converter = new Link($locationService, $contentService, $urlAliasRouter);

--- a/tests/lib/eZ/RichText/Converter/LinkTest.php
+++ b/tests/lib/eZ/RichText/Converter/LinkTest.php
@@ -226,7 +226,10 @@ class LinkTest extends TestCase
 
         $urlAliasRouter->expects($this->once())
             ->method('generate')
-            ->with($this->equalTo($location))
+            ->with(
+                $this->equalTo(UrlAliasRouter::URL_ALIAS_ROUTE_NAME),
+                $this->equalTo(['location' => $location])
+            )
             ->willReturn($urlResolved);
 
         $converter = new Link($locationService, $contentService, $urlAliasRouter);
@@ -441,7 +444,10 @@ class LinkTest extends TestCase
 
         $urlAliasRouter->expects($this->once())
             ->method('generate')
-            ->with($this->equalTo($location))
+            ->with(
+                $this->equalTo(UrlAliasRouter::URL_ALIAS_ROUTE_NAME),
+                $this->equalTo(['location' => $location])
+            )
             ->willReturn($urlResolved);
 
         $converter = new Link($locationService, $contentService, $urlAliasRouter);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow-up to [EZP-31499](https://jira.ez.no/browse/EZP-31499) and
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master` for eZ Platform 3.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Due to changes via ezsystems/ezpublish-kernel#3000 `UrlAliasRouter::generate` follows now `\Symfony\Component\Routing\Generator\UrlGeneratorInterface` prototype and does not accept `Location` directly

**TODO**:
- [x] Fix a bug.
- [x] Perform manual tests
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
