### PR TITLE
EZP-31512: Fixed extracting Search Fields from RichText

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,10 @@ matrix:
         - BEHAT_OPTS="--profile=adminui --suite=richtext"
         - SYMFONY_ENV=behat
         - SYMFONY_DEBUG=1
+# 7.3
+    - name: '[PHP 7.3] Unit tests'
+      php: 7.3
+      env: TEST_CONFIG="phpunit.xml"
 # CS check
     - name: 'Code Style Check'
       php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,5 @@ after_failure:
   - docker-compose logs -t --tail=15
   # Will show us what is up, and how long it's been up
   - docker ps -s
-  -
 after_script:
   - if [ "${BEHAT_OPTS}" != "" ] ; then bin/ezreport ; fi

--- a/src/lib/eZ/FieldType/RichText/SearchField.php
+++ b/src/lib/eZ/FieldType/RichText/SearchField.php
@@ -58,11 +58,11 @@ class SearchField implements Indexable
     {
         $text = '';
 
-        if ($node->childNodes) {
+        if (null !== $node->childNodes && $node->childNodes->length > 0) {
             foreach ($node->childNodes as $child) {
                 $text .= $this->extractText($child);
             }
-        } else {
+        } elseif (!empty($node->nodeValue)) {
             $text .= $node->nodeValue . ' ';
         }
 

--- a/tests/lib/eZ/FieldType/RichText/SearchFieldTest.php
+++ b/tests/lib/eZ/FieldType/RichText/SearchFieldTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\Tests\EzPlatformRichText\eZ\FieldType\RichText;
+
+use EzSystems\EzPlatformRichText\eZ\FieldType\RichText\SearchField;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\FieldValue;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\Search;
+use PHPUnit\Framework\TestCase;
+
+final class SearchFieldTest extends TestCase
+{
+    /** @var \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\SearchField */
+    private $searchField;
+
+    public function getDataForTestGetIndexData(): array
+    {
+        return [
+            'simple stub' => [
+                $this->getSimpleDocBookXml(),
+                [
+                    new Search\Field(
+                        'value',
+                        'Welcome to eZ Platform',
+                        new Search\FieldType\StringField()
+                    ),
+                    new Search\Field(
+                        'fulltext',
+                        "\n   Welcome to eZ Platform \n   eZ Platform  is the new generation DXP from eZ Systems. \n ",
+                        new Search\FieldType\FullTextField()
+                    ),
+                ],
+            ],
+            'empty xml' => [
+                $this->getEmptyXml(),
+                [
+                    new Search\Field(
+                        'value',
+                        '',
+                        new Search\FieldType\StringField()
+                    ),
+                    new Search\Field(
+                        'fulltext',
+                        '',
+                        new Search\FieldType\FullTextField()
+                    ),
+                ],
+            ],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->searchField = new SearchField();
+    }
+
+    /**
+     * @covers \EzSystems\EzPlatformRichText\eZ\FieldType\RichText\SearchField::getIndexData
+     *
+     * @dataProvider getDataForTestGetIndexData
+     *
+     * @param array $expectedSearchFields
+     */
+    public function testGetIndexData(string $docBookXml, array $expectedSearchFields): void
+    {
+        $field = new Field(
+            [
+                'id' => 1,
+                'type' => 'ezrichtext',
+                'value' => new FieldValue(['data' => $docBookXml]),
+            ]
+        );
+        $fieldDefinition = new FieldDefinition();
+
+        self::assertEquals(
+            $expectedSearchFields,
+            $this->searchField->getIndexData($field, $fieldDefinition)
+        );
+    }
+
+    private function getSimpleDocBookXml(): string
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="https://ezplatform.com/xmlns/docbook/xhtml">
+  <title ezxhtml:level="2">Welcome to eZ Platform</title>
+  <para><link xlink:href="ezurl://1" xlink:show="none">eZ Platform</link> is the new generation DXP from eZ Systems.</para>
+</section>
+XML;
+    }
+
+    private function getEmptyXml(): string
+    {
+        return '<?xml version="1.0" encoding="UTF-8"?><section></section>';
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31512](https://jira.ez.no/browse/EZP-31512)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.1.x` for eZ Platform 2.5.x LTS
| **BC breaks**      | no
| **Tests pass**     | [yes](https://travis-ci.org/github/ezsystems/ezplatform-richtext/builds/666501464)
| **Doc needed**     | no

This is a port of ezsystems/ezpublish-kernel#3008, see description there for all the details.

This PR actually fixes issue with production code.

I've also added Travis job for unit tests on PHP 7.3.


**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Wait for Travis
- ~Ask for Code Review.~ review in ezsystems/ezpublish-kernel#3008
