### PR TITLE
EZP-29196: Handled line breaks inside itemized/ordered lists

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -60,7 +60,7 @@
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template match="ezxhtml5:p" name="paragraph">>
+  <xsl:template match="ezxhtml5:p" name="paragraph">
     <para>
       <xsl:if test="@id">
         <xsl:attribute name="xml:id">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -60,7 +60,7 @@
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template match="ezxhtml5:p">
+  <xsl:template match="ezxhtml5:p" name="paragraph">>
     <para>
       <xsl:if test="@id">
         <xsl:attribute name="xml:id">
@@ -366,9 +366,7 @@
           <xsl:apply-templates/>
         </xsl:when>
         <xsl:otherwise>
-          <para>
-            <xsl:apply-templates/>
-          </para>
+          <xsl:call-template name="paragraph"/>
         </xsl:otherwise>
       </xsl:choose>
     </listitem>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/008-orderedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/008-orderedList.xml
@@ -8,12 +8,28 @@
     <ezattribute>
       <ezvalue key="name-1">value 1</ezvalue>
       <ezvalue key="name-2">value 2</ezvalue>
+      <ezvalue key="name-3">value 3</ezvalue>
     </ezattribute>
     <listitem ezxhtml:class="listItemClass">
       <ezattribute>
         <ezvalue key="name-2">value 2</ezvalue>
       </ezattribute>
-      <para>This is a list item.</para>
+      <para ezxhtml:class="listitemclass">
+        <ezattribute>
+          <ezvalue key="name-2">value 2</ezvalue>
+        </ezattribute>This is a list item.</para>
+    </listitem>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-3">value 3</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listitemclass">
+        <ezattribute>
+          <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <literallayout class="normal">this is a list item
+with a line break.</literallayout>
+      </para>
     </listitem>
   </orderedlist>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/008-orderedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/008-orderedList.xml
@@ -14,7 +14,7 @@
       <ezattribute>
         <ezvalue key="name-2">value 2</ezvalue>
       </ezattribute>
-      <para ezxhtml:class="listitemclass">
+      <para ezxhtml:class="listItemClass">
         <ezattribute>
           <ezvalue key="name-2">value 2</ezvalue>
         </ezattribute>This is a list item.</para>
@@ -23,11 +23,11 @@
       <ezattribute>
         <ezvalue key="name-3">value 3</ezvalue>
       </ezattribute>
-      <para ezxhtml:class="listitemclass">
+      <para ezxhtml:class="listItemClass">
         <ezattribute>
           <ezvalue key="name-3">value 3</ezvalue>
         </ezattribute>
-        <literallayout class="normal">this is a list item
+        <literallayout class="normal">This is a list item
 with a line break.</literallayout>
       </para>
     </listitem>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/009-itemizedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/009-itemizedList.xml
@@ -8,12 +8,28 @@
     <ezattribute>
       <ezvalue key="name-1">value 1</ezvalue>
       <ezvalue key="name-2">value 2</ezvalue>
+      <ezvalue key="name-3">value 3</ezvalue>
     </ezattribute>
     <listitem ezxhtml:class="listItemClass">
       <ezattribute>
         <ezvalue key="name-2">value 2</ezvalue>
       </ezattribute>
-      <para>This is a list item.</para>
+      <para ezxhtml:class="listitemclass">
+        <ezattribute>
+          <ezvalue key="name-2">value 2</ezvalue>
+        </ezattribute>This is a list item.</para>
+    </listitem>
+    <listitem ezxhtml:class="listItemClass">
+      <ezattribute>
+        <ezvalue key="name-3">value 3</ezvalue>
+      </ezattribute>
+      <para ezxhtml:class="listitemclass">
+        <ezattribute>
+          <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <literallayout class="normal">This is a list item
+with a line break.</literallayout>
+      </para>
     </listitem>
   </itemizedlist>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/009-itemizedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/009-itemizedList.xml
@@ -14,7 +14,7 @@
       <ezattribute>
         <ezvalue key="name-2">value 2</ezvalue>
       </ezattribute>
-      <para ezxhtml:class="listitemclass">
+      <para ezxhtml:class="listItemClass">
         <ezattribute>
           <ezvalue key="name-2">value 2</ezvalue>
         </ezattribute>This is a list item.</para>
@@ -23,7 +23,7 @@
       <ezattribute>
         <ezvalue key="name-3">value 3</ezvalue>
       </ezattribute>
-      <para ezxhtml:class="listitemclass">
+      <para ezxhtml:class="listItemClass">
         <ezattribute>
           <ezvalue key="name-3">value 3</ezvalue>
         </ezattribute>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/010-htmlInformaltable.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/010-htmlInformaltable.xml
@@ -38,7 +38,7 @@
           </ezattribute>
           <para>21</para>
           <itemizedlist ezxhtml:class="itemizedListClass">
-            <listitem ezxhtml:class="listItemClass"><para>This is a list item.</para></listitem>
+            <listitem ezxhtml:class="listItemClass"><para ezxhtml:class="listitemclass">This is a list item.</para></listitem>
           </itemizedlist>
         </td>
         <td class="cellClass2" ezxhtml:width="38" valign="baseline" colspan="4" rowspan="8">

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/010-htmlInformaltable.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/010-htmlInformaltable.xml
@@ -38,7 +38,7 @@
           </ezattribute>
           <para>21</para>
           <itemizedlist ezxhtml:class="itemizedListClass">
-            <listitem ezxhtml:class="listItemClass"><para ezxhtml:class="listitemclass">This is a list item.</para></listitem>
+            <listitem ezxhtml:class="listItemClass"><para ezxhtml:class="listItemClass">This is a list item.</para></listitem>
           </itemizedlist>
         </td>
         <td class="cellClass2" ezxhtml:width="38" valign="baseline" colspan="4" rowspan="8">

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/008-orderedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/008-orderedList.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" id="orderedlist-id">
+  <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="orderedlist-id">
     <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
   </ol>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/009-itemizedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/009-itemizedList.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2">
+  <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3">
     <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
   </ul>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/004-itemizedList.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/004-itemizedList.docbook.xml
@@ -12,5 +12,11 @@
         <listitem>
             <para>Some list item with a paragraph.</para>
         </listitem>
+        <listitem>
+            <para>
+                <literallayout class="normal">Some list item
+with a line break.</literallayout>
+            </para>
+        </listitem>
     </itemizedlist>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/004-itemizedList.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/004-itemizedList.xhtml5.edit.xml
@@ -3,5 +3,6 @@
     <ul>
         <li>Some list item.</li>
         <li><p>Some list item with a paragraph.</p></li>
+        <li>Some list item<br/>with a line break.</li>
     </ul>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/005-orderedList.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/005-orderedList.docbook.xml
@@ -12,5 +12,11 @@
         <listitem>
             <para>Some list item with a paragraph.</para>
         </listitem>
+        <listitem>
+            <para>
+                <literallayout class="normal">Some list item
+with a line break.</literallayout>
+            </para>
+        </listitem>
     </orderedlist>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/005-orderedList.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/005-orderedList.xhtml5.edit.xml
@@ -3,5 +3,6 @@
     <ol>
         <li>Some list item.</li>
         <li><p>Some list item with a paragraph.</p></li>
+        <li>Some list item<br/>with a line break.</li>
     </ol>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/008-orderedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/008-orderedList.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" id="orderedlist-id">
+  <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="orderedlist-id">
     <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
   </ol>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/009-itemizedList.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/009-itemizedList.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2">
+  <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3">
     <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+    <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item<br/>with a line break.</li>
   </ul>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29196](https://jira.ez.no/browse/EZP-29196)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.1` and `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently, DocBook schema for ordered/itemized list doesn't contain proper handling of paragraphs that results in not reflecting break lines. The idea is to reuse an already implemented rule for paragraph (`ezxhtml5:p`).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
