### PR TITLE
EZP-31246: [Tests] Refactored tests not to rely on eZc Database

### DIFF
--- a/tests/integration/eZ/SPI/RichTextFieldTypeIntegrationTest.php
+++ b/tests/integration/eZ/SPI/RichTextFieldTypeIntegrationTest.php
@@ -76,7 +76,7 @@ class RichTextFieldTypeIntegrationTest extends BaseIntegrationTest
         $fieldType = new Type($inputHandler);
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 
-        $urlGateway = new UrlGateway($this->getDatabaseHandler()->getConnection());
+        $urlGateway = new UrlGateway($this->getDatabaseConnection());
 
         return $this->getHandler(
             'ezrichtext',
@@ -85,7 +85,7 @@ class RichTextFieldTypeIntegrationTest extends BaseIntegrationTest
             new RichTextStorage(
                 new DoctrineStorage(
                     $urlGateway,
-                    $this->getDatabaseHandler()->getConnection()
+                    $this->getDatabaseConnection()
                 )
             )
         );

--- a/tests/lib/eZ/FieldType/RichText/Gateway/DoctrineStorageTest.php
+++ b/tests/lib/eZ/FieldType/RichText/Gateway/DoctrineStorageTest.php
@@ -51,7 +51,7 @@ class DoctrineStorageTest extends TestCase
     protected function getStorageGateway()
     {
         if (!isset($this->storageGateway)) {
-            $connection = $this->getDatabaseHandler()->getConnection();
+            $connection = $this->getDatabaseConnection();
             $urlGateway = new UrlStorageDoctrineGateway($connection);
             $this->storageGateway = new DoctrineStorage($urlGateway, $connection);
         }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31246](https://jira.ez.no/browse/EZP-31246)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master` (package internal test setup)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR replaces 2 remaining usages of Zeta Components Database Handler from tests.

**TODO**:
- [x] Fix tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
