### PR TITLE
EZP-30940: Cannot remove table from richtext field

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-tableremove.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-tableremove.js
@@ -13,7 +13,10 @@ export default class EzBtnTableRemove extends AlloyEditor.ButtonTableRemove {
                 aria-label={AlloyEditor.Strings.deleteTable}
                 className="ae-button ez-btn-ae"
                 data-type="button-table-remove"
-                onClick={this._removeTable}
+                onClick={() => {
+                    this._removeTable();
+                    this.fireCustomUpdateEvent();
+                }}
                 tabIndex={this.props.tabIndex}
                 title={AlloyEditor.Strings.deleteTable}>
                 <svg className="ez-icon ez-btn-ae__icon">
@@ -21,6 +24,12 @@ export default class EzBtnTableRemove extends AlloyEditor.ButtonTableRemove {
                 </svg>
             </button>
         );
+    }
+
+    fireCustomUpdateEvent() {
+        const nativeEditor = this.props.editor.get('nativeEditor');
+
+        nativeEditor.fire('customUpdate');
     }
 }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30940](https://jira.ez.no/browse/EZP-30940)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This is a followup for https://github.com/ezsystems/ezplatform-admin-ui/pull/1321 targeting 3.0.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
