### PR TITLE
EZEE-3094: Added missing int casting in the RelationProcessor::getRelatedObjectIds

### DIFF
--- a/src/lib/eZ/RichText/RelationProcessor.php
+++ b/src/lib/eZ/RichText/RelationProcessor.php
@@ -80,9 +80,9 @@ final class RelationProcessor
                 }
 
                 if ($scheme === 'ezcontent') {
-                    $contentIds[] = $id;
+                    $contentIds[] = (int)$id;
                 } elseif ($scheme === 'ezlocation') {
-                    $locationIds[] = $id;
+                    $locationIds[] = (int)$id;
                 }
             }
         }

--- a/tests/lib/eZ/RichText/RelationProcessorTest.php
+++ b/tests/lib/eZ/RichText/RelationProcessorTest.php
@@ -31,7 +31,7 @@ class RelationProcessorTest extends TestCase
     {
         $actualProcessor = (new RelationProcessor())->getRelations($document);
 
-        $this->assertEquals($expectedRelations, $actualProcessor);
+        $this->assertSame($expectedRelations, $actualProcessor);
     }
 
     public function dateProviderForGetRelations(): array


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-3094](https://jira.ez.no/browse/EZEE-3094)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
