### PR TITLE
[Tests] Aligned SetupFactory to include PermissionService

### DIFF
--- a/tests/integration/eZ/API/SetupFactory/CoreSetupFactoryTrait.php
+++ b/tests/integration/eZ/API/SetupFactory/CoreSetupFactoryTrait.php
@@ -47,6 +47,7 @@ trait CoreSetupFactoryTrait
         $loader->load('repository/inner.yml');
         $loader->load('repository/event.yml');
         $loader->load('repository/siteaccessaware.yml');
+        $loader->load('repository/autowire.yml');
         $loader->load('roles.yml');
         $loader->load('storage_engines/common.yml');
         $loader->load('storage_engines/cache.yml');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Follow up for [EZP-30465](https://jira.ez.no/browse/EZP-30465) introduced via ezsystems/ezplatform-kernel#44
| **Bug/Improvement**| yes
| **Target version** | Test setup of eZ Platform v3.0.x
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This is a follow-up aligning integration tests SetupFactory with changes from ezsystems/ezplatform-kernel#44. Config for `autowire.yml` was not loaded. 

Please note that this not very DRY solution needs to be changed, but here it's out of scope. The scope here is to unblock failing CI: https://travis-ci.org/github/ezsystems/ezplatform-richtext/builds/674730281.

**TODO**:
- [x] Fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.