### PR TITLE
EZP-30861: Handled line breaks inside headings

### DIFF
--- a/src/lib/eZ/RichText/Resources/schemas/docbook/docbook.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/docbook.rng
@@ -1120,7 +1120,10 @@
         <a:documentation>The text of the title of a section of a document or of a formal block-level element</a:documentation>
         <ref name="db.title.attlist"/>
         <zeroOrMore>
-          <ref name="db.all.inlines"/>
+          <choice>
+            <ref name="db.all.inlines"/>
+            <ref name="db.literallayout"/>
+          </choice>
         </zeroOrMore>
       </element>
     </define>

--- a/src/lib/eZ/RichText/Resources/schemas/docbook/docbook.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/docbook.rng
@@ -1120,10 +1120,7 @@
         <a:documentation>The text of the title of a section of a document or of a formal block-level element</a:documentation>
         <ref name="db.title.attlist"/>
         <zeroOrMore>
-          <choice>
-            <ref name="db.all.inlines"/>
-            <ref name="db.literallayout"/>
-          </choice>
+          <ref name="db.all.inlines"/>
         </zeroOrMore>
       </element>
     </define>

--- a/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -22,6 +22,16 @@
       </a:documentation>
       <ref name="db.title"/>
     </define>
+    <define name="db.all.inlines">
+      <choice>
+        <text/>
+        <ref name="db.ubiq.inlines"/>
+        <ref name="db.general.inlines"/>
+        <ref name="db.domain.inlines"/>
+        <ref name="db.extension.inlines"/>
+        <ref name="db.literallayout"/>
+      </choice>
+    </define>
 
     <define name="db.blockquote.info" combine="choice">
       <a:documentation>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -139,6 +139,12 @@
     </xsl:call-template>
   </xsl:template>
 
+  <xsl:template match="docbook:title/docbook:literallayout">
+    <xsl:call-template name="paragraphLiterallayout">
+      <xsl:with-param name="nodes" select="node()"/>
+    </xsl:call-template>
+  </xsl:template>
+
   <xsl:template match="docbook:emphasis/text()">
     <xsl:choose>
       <xsl:when test="ancestor::*[local-name() = 'literallayout']">

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -139,6 +139,12 @@
     </xsl:call-template>
   </xsl:template>
 
+  <xsl:template match="docbook:title/docbook:literallayout">
+    <xsl:call-template name="paragraphLiterallayout">
+      <xsl:with-param name="nodes" select="node()"/>
+    </xsl:call-template>
+  </xsl:template>
+
   <xsl:template match="docbook:emphasis/text()">
     <xsl:choose>
       <xsl:when test="ancestor::*[local-name() = 'literallayout']">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -315,7 +315,25 @@
         </xsl:if>
       </xsl:if>
       <xsl:call-template name="ezattribute"/>
-      <xsl:apply-templates/>
+      <xsl:choose>
+        <xsl:when test="descendant::ezxhtml5:br">
+          <literallayout class="normal">
+            <xsl:for-each select="node()">
+              <xsl:choose>
+                <xsl:when test="local-name( current() ) = 'br'">
+                  <xsl:text>&#xA;</xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:apply-templates select="current()"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:for-each>
+          </literallayout>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates/>
+        </xsl:otherwise>
+      </xsl:choose>
     </title>
   </xsl:template>
 

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -39,6 +39,8 @@
       </xsl:element>
     </xsl:if>
   </xsl:template>
+
+  <!-- Note: use only in context where literallayout is handled always in parent context -->
   <xsl:template name="breakline">
     <xsl:param name="node"/>
     <xsl:choose>
@@ -53,6 +55,29 @@
             </xsl:otherwise>
           </xsl:choose>
         </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="breaklineWithLiterallayout">
+    <xsl:param name="node"/>
+    <xsl:choose>
+      <xsl:when test="descendant::ezxhtml5:br">
+        <literallayout class="normal">
+          <xsl:for-each select="$node">
+            <xsl:choose>
+              <xsl:when test="local-name( current() ) = 'br'">
+                <xsl:text>&#xA;</xsl:text>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:apply-templates select="current()"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:for-each>
+        </literallayout>
       </xsl:when>
       <xsl:otherwise>
         <xsl:apply-templates/>
@@ -86,25 +111,9 @@
         </xsl:if>
       </xsl:if>
       <xsl:call-template name="ezattribute"/>
-      <xsl:choose>
-        <xsl:when test="descendant::ezxhtml5:br">
-          <literallayout class="normal">
-            <xsl:for-each select="node()">
-              <xsl:choose>
-                <xsl:when test="local-name( current() ) = 'br'">
-                  <xsl:text>&#xA;</xsl:text>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:apply-templates select="current()"/>
-                </xsl:otherwise>
-              </xsl:choose>
-            </xsl:for-each>
-          </literallayout>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:apply-templates/>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:call-template name="breaklineWithLiterallayout">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
     </para>
   </xsl:template>
 
@@ -315,25 +324,9 @@
         </xsl:if>
       </xsl:if>
       <xsl:call-template name="ezattribute"/>
-      <xsl:choose>
-        <xsl:when test="descendant::ezxhtml5:br">
-          <literallayout class="normal">
-            <xsl:for-each select="node()">
-              <xsl:choose>
-                <xsl:when test="local-name( current() ) = 'br'">
-                  <xsl:text>&#xA;</xsl:text>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:apply-templates select="current()"/>
-                </xsl:otherwise>
-              </xsl:choose>
-            </xsl:for-each>
-          </literallayout>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:apply-templates/>
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:call-template name="breaklineWithLiterallayout">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
     </title>
   </xsl:template>
 

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/001-title.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/001-title.xml
@@ -9,4 +9,8 @@
   <title ezxhtml:level="3" ezxhtml:textalign="center">This is a centered heading.</title>
   <title ezxhtml:level="3" ezxhtml:textalign="right">This is a right aligned heading.</title>
   <title ezxhtml:level="3" ezxhtml:textalign="justify">This is a justified heading.</title>
+  <title ezxhtml:level="4" ezxhtml:class="titleClass3">
+    <literallayout class="normal">This is a heading
+with a line break.</literallayout>
+  </title>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/001-title.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/001-title.xml
@@ -5,4 +5,5 @@
   <h3 style="text-align:center;">This is a centered heading.</h3>
   <h3 style="text-align:right;">This is a right aligned heading.</h3>
   <h3 style="text-align:justify;">This is a justified heading.</h3>
+  <h4 class="titleClass3">This is a heading<br/>with a line break.</h4>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/001-title.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/001-title.xml
@@ -5,4 +5,5 @@
   <h3 style="text-align:center;">This is a centered heading.</h3>
   <h3 style="text-align:right;">This is a right aligned heading.</h3>
   <h3 style="text-align:justify;">This is a justified heading.</h3>
+  <h4 class="titleClass3">This is a heading<br/>with a line break.</h4>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30861](https://jira.ez.no/browse/EZP-30861)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.1`, `2.0`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently, there is another inconsistent scenario when line breaks appear inside headings (`<h1> - <h6>`). As `literallayout` tag responsible for correctly displaying breaklines cannot be placed inside `<title>` tag (according to DocBook schema), I adjusted `docbook.rng` to reflect this case. As `db.all.inlines` rules are used in many places, I decided to add `literallayout` only to `title` element to avoid potential issues. XSL logic is basically about reusing existing rules for the paragraph - we don't want to add `literallayout` to `title` when there are no line breaks, so those scenarios are left untouched.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
