### PR TITLE
EZP-31547: Autowiring fails for CustomTag service when using 3rd party translator bundle

### DIFF
--- a/src/bundle/Resources/config/ui/mappers.yaml
+++ b/src/bundle/Resources/config/ui/mappers.yaml
@@ -24,6 +24,7 @@ services:
     EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomTag:
         arguments:
             $customTagsConfiguration: '%ezplatform.ezrichtext.custom_tags%'
+            $translatorBag: '@translator'
             $translationDomain: '%ezrichtext.custom_tags.translation_domain%'
             $customTagAttributeMappers: !tagged ezrichtext.configuration.custom_tag.mapper
 

--- a/src/lib/Configuration/UI/Mapper/CustomTag.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag.php
@@ -11,6 +11,7 @@ namespace EzSystems\EzPlatformRichText\Configuration\UI\Mapper;
 use EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomTag\AttributeMapper;
 use RuntimeException;
 use Symfony\Component\Asset\Packages;
+use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Traversable;
 
@@ -26,6 +27,9 @@ final class CustomTag implements CustomTemplateConfigMapper
 
     /** @var \Symfony\Contracts\Translation\TranslatorInterface */
     private $translator;
+
+    /** @var \Symfony\Component\Translation\TranslatorBagInterface */
+    private $translatorBag;
 
     /** @var \Symfony\Component\Asset\Packages */
     private $packages;
@@ -47,6 +51,7 @@ final class CustomTag implements CustomTemplateConfigMapper
      *
      * @param array $customTagsConfiguration
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator
+     * @param \Symfony\Component\Translation\TranslatorBagInterface $translatorBag
      * @param string $translationDomain
      * @param \Symfony\Component\Asset\Packages $packages
      * @param \Traversable $customTagAttributeMappers
@@ -54,12 +59,14 @@ final class CustomTag implements CustomTemplateConfigMapper
     public function __construct(
         array $customTagsConfiguration,
         TranslatorInterface $translator,
+        TranslatorBagInterface $translatorBag,
         string $translationDomain,
         Packages $packages,
         Traversable $customTagAttributeMappers
     ) {
         $this->customTagsConfiguration = $customTagsConfiguration;
         $this->translator = $translator;
+        $this->translatorBag = $translatorBag;
         $this->translationDomain = $translationDomain;
         $this->packages = $packages;
         $this->customTagAttributeMappers = $customTagAttributeMappers;
@@ -171,7 +178,7 @@ final class CustomTag implements CustomTemplateConfigMapper
                 continue;
             }
 
-            $transCatalogue = $this->translator->getCatalogue();
+            $transCatalogue = $this->translatorBag->getCatalogue();
             foreach ($tagConfig['attributes'] as $attributeName => $attributeConfig) {
                 $config[$tagName]['attributes'][$attributeName]['label'] = $this->translator->trans(
                     /** @Ignore */

--- a/tests/lib/Configuration/UI/Mapper/CustomTagTest.php
+++ b/tests/lib/Configuration/UI/Mapper/CustomTagTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * UI Config Mapper test for RichText Custom Tags configuration.
@@ -39,7 +41,8 @@ class CustomTagTest extends TestCase
     ) {
         $mapper = new CustomTag(
             $customTagsConfiguration,
-            $this->getTranslatorMock(),
+            $this->getTranslatorInterfaceMock(),
+            $this->getTranslatorBagInterfaceMock(),
             'custom_tags',
             $this->getPackagesMock(),
             new ArrayObject(
@@ -173,7 +176,22 @@ class CustomTagTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|\Symfony\Contracts\Translation\TranslatorInterface
      */
-    private function getTranslatorMock(): MockObject
+    private function getTranslatorInterfaceMock(): MockObject
+    {
+        $translatorInterfaceMock = $this->createMock(TranslatorInterface::class);
+        $translatorInterfaceMock
+            ->expects($this->any())
+            ->method('trans')
+            ->withAnyParameters()
+            ->willReturnArgument(0);
+
+        return $translatorInterfaceMock;
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Translation\TranslatorBagInterface
+     */
+    private function getTranslatorBagInterfaceMock(): MockObject
     {
         $catalogueMock = $this->createMock(MessageCatalogueInterface::class);
         $catalogueMock
@@ -182,21 +200,15 @@ class CustomTagTest extends TestCase
             ->withAnyParameters()
             ->willReturn(false);
 
-        $translatorMock = $this->createMock(Translator::class);
-        $translatorMock
+        $translatorBagInterfaceMock = $this->createMock(TranslatorBagInterface::class);
+        $translatorBagInterfaceMock
             ->expects($this->any())
             ->method('getCatalogue')
             ->willReturn(
                 $catalogueMock
             );
 
-        $translatorMock
-            ->expects($this->any())
-            ->method('trans')
-            ->withAnyParameters()
-            ->willReturnArgument(0);
-
-        return $translatorMock;
+        return $translatorBagInterfaceMock;
     }
 
     /**

--- a/tests/lib/Configuration/UI/Mapper/CustomTagTest.php
+++ b/tests/lib/Configuration/UI/Mapper/CustomTagTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Translation\MessageCatalogueInterface;
-use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31547](https://jira.ez.no/browse/EZP-31547)
| **Bug**| yes
| **Target version** | 2.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Merge up for https://github.com/ezsystems/ezplatform-admin-ui/pull/1335