### PR TITLE
EZP-31612: use custom tag choice labels

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-customtag-update.js
@@ -114,7 +114,7 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
                     value={this.state.values[attrName].value}
                     onChange={this.updateValues.bind(this)}
                     data-attr-name={attrName}>
-                    {config.choices.map(this.renderChoice.bind(this))}
+                    {config.choices.map((choice) => this.renderChoice(choice, config.choicesLabel[choice]))}
                 </select>
             </div>
         );
@@ -138,10 +138,11 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
      *
      * @method renderChoice
      * @param {String} choice
+     * @param {String} label
      * @return {Object} The rendered option.
      */
-    renderChoice(choice) {
-        return <option value={choice}>{choice}</option>;
+    renderChoice(choice, label) {
+        return <option value={choice}>{label}</option>;
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31612](https://jira.ez.no/browse/EZP-31612)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 2.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**Steps to reproduce:**
1. Create a custom tag with choices attribute:
```
custom_tags:
    factbox:
        template: '@ezdesign/custom_tag/factbox.html.twig'
        icon: '/bundles/factbox/img/icons.svg'
        is_inline: false
        attributes:
            options:
                type: choice
                choices:
                    - option1
                    - option2
                default_value: option1
                required: true
```
2. Create translations for choice labels:
```
ezrichtext.custom_tags.factbox.attributes.options.choices.option1.label: 'Option 1'
ezrichtext.custom_tags.factbox.attributes.options.choices.option2.label: 'Option 2'
```
3. Open OE and insert the custom tag

**Expected result:**
Choice label translations will be shown

**Actual result:**
Choice values are shown instead of translated labels


**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
