### PR TITLE
EZP-31626: Fixed rendering of embed locations

### DIFF
--- a/src/bundle/eZ/RichText/Renderer.php
+++ b/src/bundle/eZ/RichText/Renderer.php
@@ -542,14 +542,14 @@ class Renderer implements RendererInterface
                 new AuthorizationAttribute(
                     'content',
                     'read',
-                    ['valueObject' => $location->contentInfo, 'targets' => $location]
+                    ['valueObject' => $location->contentInfo, 'targets' => [$location]]
                 )
             )
             && !$this->authorizationChecker->isGranted(
                 new AuthorizationAttribute(
                     'content',
                     'view_embed',
-                    ['valueObject' => $location->contentInfo, 'targets' => $location]
+                    ['valueObject' => $location->contentInfo, 'targets' => [$location]]
                 )
             )
         ) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31626](https://jira.ez.no/browse/EZP-31626)
| **Requires** | https://github.com/ezsystems/ezplatform-admin-ui/pull/1374
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 2.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

We faced this issue during upgrade to eZ Platform v3 from eZ Publish. And seems like the only `ezcontent://` links are used in eZ Platform v3 UI, which makes hard to reproduce it on the clean eZ Platform v3.0.3 installation.

**Steps to reproduce**
 1. Create a new Article, and embed location in its RichText field. The simplest way is to use [https://gitlab.com/contextualcode/ezplatform-alloyeditor-source] and add the following HTML:
```
<div data-ezelement="ezembed" data-href="ezlocation://2" data-ezview="embed" data-ez-node-initialized="true">&nbsp;</div>
```
2. Save the new article and open its full view page.

**Expected result**
 Embed location will be rendered

**Actual result**
 The following exception is thrown:
```
Argument 4 passed to eZ\Publish\Core\Repository\Permission\CachedPermissionService::canUser() must be of the type array, object given, called in XXX/vendor/ezsystems/ezplatform-kernel/eZ/Publish/Core/MVC/Symfony/Security/Authorization/Voter/ValueObjectVoter.php on line 63
```


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
