### PR TITLE
EZP-31632: Floating table toolbar

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
@@ -133,14 +133,23 @@ export default class EzBtnLinkEdit extends Component {
      */
     showUI() {
         const nativeEditor = this.props.editor.get('nativeEditor');
-
-        nativeEditor.fire('editorInteraction', {
+        const eventOptions = {
             editor: this.props.editor,
             selectionData: {
                 element: this.state.element,
                 region: this.getRegion(),
             },
-        });
+        };
+        const path = nativeEditor.elementPath();
+
+        if (path) {
+            eventOptions.nativeEvent = {
+                editor: this.props.editor,
+                target: path.lastElement.$,
+            };
+        }
+
+        nativeEditor.fire('editorInteraction', eventOptions);
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
@@ -133,14 +133,9 @@ export default class EzBtnLinkEdit extends Component {
      */
     showUI() {
         const nativeEditor = this.props.editor.get('nativeEditor');
-        const element = nativeEditor.elementPath().lastElement;
 
         nativeEditor.fire('editorInteraction', {
             editor: this.props.editor,
-            nativeEvent: {
-                editor: this.props.editor,
-                target: element.$,
-            },
             selectionData: {
                 element: this.state.element,
                 region: this.getRegion(),

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
@@ -133,23 +133,19 @@ export default class EzBtnLinkEdit extends Component {
      */
     showUI() {
         const nativeEditor = this.props.editor.get('nativeEditor');
-        const eventOptions = {
+        const element = nativeEditor.elementPath().lastElement;
+
+        nativeEditor.fire('editorInteraction', {
             editor: this.props.editor,
+            nativeEvent: {
+                editor: this.props.editor,
+                target: element.$,
+            },
             selectionData: {
                 element: this.state.element,
                 region: this.getRegion(),
             },
-        };
-        const path = nativeEditor.elementPath();
-
-        if (path) {
-            eventOptions.nativeEvent = {
-                editor: this.props.editor,
-                target: path.lastElement.$,
-            };
-        }
-
-        nativeEditor.fire('editorInteraction', eventOptions);
+        });
     }
 
     /**

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
@@ -135,10 +135,6 @@ export default class EzBtnLinkEdit extends Component {
         const nativeEditor = this.props.editor.get('nativeEditor');
         const eventOptions = {
             editor: this.props.editor,
-            nativeEvent: {
-                editor: this.props.editor,
-                target: element.$,
-            },
             selectionData: {
                 element: this.state.element,
                 region: this.getRegion(),

--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
@@ -135,6 +135,10 @@ export default class EzBtnLinkEdit extends Component {
         const nativeEditor = this.props.editor.get('nativeEditor');
         const eventOptions = {
             editor: this.props.editor,
+            nativeEvent: {
+                editor: this.props.editor,
+                target: element.$,
+            },
             selectionData: {
                 element: this.state.element,
                 region: this.getRegion(),

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-fixed.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-fixed.js
@@ -10,9 +10,8 @@ export default class EzConfigFixedBase extends EzConfigBase {
         const editorRect = editor.element.getClientRect();
         const toolbarHeight = toolbar ? toolbar.getBoundingClientRect().height : 0;
         const shouldBeFixed = editorRect.top - toolbarHeight - 2 * TOOLBAR_OFFSET < 0;
-        const header = document.querySelector('.ez-edit-header__content-type-name');
         const top = shouldBeFixed
-            ? TOOLBAR_OFFSET + (header ? header.offsetHeight : 0)
+            ? TOOLBAR_OFFSET
             : editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbarHeight - TOOLBAR_OFFSET;
 
         if (toolbar) {

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-fixed.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-fixed.js
@@ -10,8 +10,9 @@ export default class EzConfigFixedBase extends EzConfigBase {
         const editorRect = editor.element.getClientRect();
         const toolbarHeight = toolbar ? toolbar.getBoundingClientRect().height : 0;
         const shouldBeFixed = editorRect.top - toolbarHeight - 2 * TOOLBAR_OFFSET < 0;
+        const header = document.querySelector('.ez-edit-header__content-type-name');
         const top = shouldBeFixed
-            ? TOOLBAR_OFFSET
+            ? TOOLBAR_OFFSET + (header ? header.offsetHeight : 0)
             : editorRect.top + editor.element.getWindow().getScrollPosition().y - toolbarHeight - TOOLBAR_OFFSET;
 
         if (toolbar) {

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
@@ -1,18 +1,18 @@
-import AlloyEditor from 'alloyeditor';
-import EzConfigButtonsBase from './base-buttons';
+import EzConfigBase from './base';
 
-export default class EzConfigTableBase extends EzConfigButtonsBase {
+export default class EzConfigTableBase extends EzConfigBase {
     constructor(config) {
         super(config);
 
         this.name = this.getConfigName();
         this.buttons = this.getButtons(config);
-
-        this.getArrowBoxClasses = AlloyEditor.SelectionGetArrowBoxClasses.table;
-        this.setPosition = AlloyEditor.SelectionSetPosition.table;
     }
 
     getConfigName() {
+        return '';
+    }
+
+    getArrowBoxClasses() {
         return '';
     }
 }

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
@@ -1,6 +1,6 @@
-import EzConfigFixedBase from './base-fixed';
+import EzConfigBase from './base';
 
-export default class EzConfigTableBase extends EzConfigFixedBase {
+export default class EzConfigTableBase extends EzConfigBase {
     constructor(config) {
         super(config);
 

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
@@ -1,6 +1,6 @@
-import EzConfigBase from './base';
+import EzConfigFixedBase from './base-fixed';
 
-export default class EzConfigTableBase extends EzConfigBase {
+export default class EzConfigTableBase extends EzConfigFixedBase {
     constructor(config) {
         super(config);
 

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base-table.js
@@ -13,6 +13,6 @@ export default class EzConfigTableBase extends EzConfigFixedBase {
     }
 
     getArrowBoxClasses() {
-        return '';
+        return 'ae-toolbar-floating';
     }
 }

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base.js
@@ -84,11 +84,20 @@ export default class EzConfigBase extends EzConfigButtonsBase {
         if (!block || isWidgetElement) {
             const inlineCustomTag = path.elements.find((element) => element.$.dataset.ezelement === 'eztemplateinline');
 
-            block = inlineCustomTag || targetElement;
+            block = inlineCustomTag || path.lastElement;
         }
 
         if (block.is('li')) {
             block = block.getParent();
+        }
+
+        if (block.is('td') || block.is('th')) {
+            for (let parent of block.getParents()) {
+                if (parent.getName() === 'table') {
+                    block = parent;
+                    break;
+                }
+            }
         }
 
         return block;

--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base.js
@@ -81,10 +81,14 @@ export default class EzConfigBase extends EzConfigButtonsBase {
         const path = editor.elementPath();
         let block = path.block;
 
-        if (!block || isWidgetElement) {
+        if (isWidgetElement) {
             const inlineCustomTag = path.elements.find((element) => element.$.dataset.ezelement === 'eztemplateinline');
 
-            block = inlineCustomTag || path.lastElement;
+            block = inlineCustomTag || targetElement;
+        }
+
+        if (!block ) {
+            block = path.lastElement;
         }
 
         if (block.is('li')) {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31632](https://jira.ez.no/browse/EZP-31632)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Right now table toolbar has fixed positioning, and in some cases it brings inconvenience.

**Steps to reproduce:**
1. Open any content with RichtText field for editing
2. Insert a big table (50 rows) into RichText field
3. Scroll to the last table row and try to insert a new row after it

**Expected result**
The table toolbar should be shown on the screen, and new row should be inserted without any scrolling.

**Actual result**
The table toolbar remains at the start of the table. And the editor needs to scroll to it, to add a new row.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
