### PR TITLE
EZP-31641: Unable to manage links in table cells

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
@@ -472,6 +472,14 @@ export default class EzBtnLinkEdit extends Component {
 
             this.invokeWithFixedScrollbar(() => {
                 editor.fire('actionPerformed', this);
+
+                const pathElement = editor.elementPath().lastElement;
+                if (pathElement.getName() === 'br') {
+                    const parent = pathElement.getParent();
+                    if (parent.getName() === 'td' || parent.getName() === 'th') {
+                        editor.eZ.moveCaretToElement(editor, parent);
+                    }
+                }
             });
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31641](https://jira.ez.no/browse/EZP-31641)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 2.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**Steps to reproduce**

1. Open for editing any content with RichText field in Admin UI
2. Add an empty 3x3 table into the RichText field
3. Type "test" In the first table cell
4. Select typed text from the previous step, and make it link to "https://url.com"

**Expected results**
The cursor is moved to the next table cell and the toolbar for that cell is shown.

**Actual results**
The next table cell is selected, and the table cell toolbar is missing. The toolbar is not shown even if the user chooses any other table cell.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
