### PR TITLE
EZP-31647: more flexibility added to AttributeMapper::supports

### DIFF
--- a/src/lib/Configuration/UI/Mapper/CustomTag.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag.php
@@ -141,7 +141,7 @@ final class CustomTag implements CustomTemplateConfigMapper
 
         foreach ($this->customTagAttributeMappers as $attributeMapper) {
             // get first supporting, order of these mappers is controlled by 'priority' DI tag attribute
-            if ($attributeMapper->supports($attributeType)) {
+            if ($attributeMapper->supports($tagName, $attributeName, $attributeType)) {
                 return $this->supportedTagAttributeMappersCache[$attributeType] = $attributeMapper;
             }
         }

--- a/src/lib/Configuration/UI/Mapper/CustomTag/AttributeMapper.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag/AttributeMapper.php
@@ -18,11 +18,13 @@ interface AttributeMapper
     /**
      * Check if mapper supports given Custom Tag attribute type.
      *
+     * @param string $tagName
+     * @param string $attributeName
      * @param string $attributeType
      *
      * @return bool
      */
-    public function supports(string $attributeType): bool;
+    public function supports(string $tagName, string $attributeName, string $attributeType): bool;
 
     /**
      * Map Configuration for the given Custom Tag attribute type.

--- a/src/lib/Configuration/UI/Mapper/CustomTag/ChoiceAttributeMapper.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag/ChoiceAttributeMapper.php
@@ -15,7 +15,7 @@ namespace EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomTag;
  */
 final class ChoiceAttributeMapper extends CommonAttributeMapper implements AttributeMapper
 {
-    public function supports(string $attributeType): bool
+    public function supports(string $tagName, string $attributeName, string $attributeType): bool
     {
         return 'choice' === $attributeType;
     }

--- a/src/lib/Configuration/UI/Mapper/CustomTag/CommonAttributeMapper.php
+++ b/src/lib/Configuration/UI/Mapper/CustomTag/CommonAttributeMapper.php
@@ -18,7 +18,7 @@ class CommonAttributeMapper implements AttributeMapper
     /**
      * {@inheritdoc}
      */
-    public function supports(string $attributeType): bool
+    public function supports(string $tagName, string $attributeName, string $attributeType): bool
     {
         return true;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31647](https://jira.ez.no/browse/EZP-31647)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 2.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Before this PR `EzSystems\EzPlatformRichText\Configuration\UI\Mapper\CustomTag\AttributeMapper::supports` was accepting only `$attributeName`. But in some cases, it is vital to have attribute mappers for specific custom tags/attributes.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
