### PR TITLE
EZP-31673: RichText should use new http-cache 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "twig/twig": "^3.0",
         "ezsystems/ezplatform-kernel": "~1.0.0@dev",
         "ezsystems/ezplatform-content-forms": "~1.0.0@dev",
-        "ezsystems/ezplatform-rest": "~1.0.0@dev"
+        "ezsystems/ezplatform-rest": "~1.0.0@dev",
+        "ezsystems/ezplatform-http-cache": "^2.0@dev"
     },
     "require-dev": {
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",

--- a/src/bundle/Resources/views/RichText/embed/content.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/content.html.twig
@@ -15,7 +15,7 @@
 {% endif %}
 
 <div {% if embedParams.anchor is defined %}id="{{ embedParams.anchor }}"{% endif %} class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}"{{ data_attributes_str|raw }}>
-    {{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
+    {{ ez_http_tag_relation_ids([embedParams.id]) }}
     {{
         render(
             controller(

--- a/src/bundle/Resources/views/RichText/embed/content_denied.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/content_denied.html.twig
@@ -1,4 +1,4 @@
 <div class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
-    {{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
+    {{ ez_http_tag_relation_ids([embedParams.id]) }}
     Content #{{ embedParams.id }}: You do not have permission to view this Content
 </div>

--- a/src/bundle/Resources/views/RichText/embed/content_inline.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/content_inline.html.twig
@@ -13,7 +13,7 @@
     {% set params = params|merge( { "class": embedParams.class } ) %}
 {% endif %}
 
-{{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
+{{ ez_http_tag_relation_ids([embedParams.id]) }}
 {{
     render(
         controller(

--- a/src/bundle/Resources/views/RichText/embed/content_inline_denied.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/content_inline_denied.html.twig
@@ -1,2 +1,2 @@
-{{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
+{{ ez_http_tag_relation_ids([embedParams.id]) }}
 [[ Content #{{ embedParams.id }}: You do not have permission to view this Content ]]

--- a/src/bundle/Resources/views/RichText/embed/location.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location.html.twig
@@ -14,7 +14,7 @@
 {% endif %}
 
 <div {% if embedParams.anchor is defined %}id="{{ embedParams.anchor }}"{% endif %} class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
-    {{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
+    {{ ez_http_tag_relation_location_ids([embedParams.id]) }}
     {{
         render(
             controller(

--- a/src/bundle/Resources/views/RichText/embed/location_denied.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location_denied.html.twig
@@ -1,4 +1,4 @@
 <div class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
-    {{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
+    {{ ez_http_tag_relation_location_ids([embedParams.id]) }}
     Location #{{ embedParams.id }}: You do not have permission to view this Location
 </div>

--- a/src/bundle/Resources/views/RichText/embed/location_inline.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location_inline.html.twig
@@ -13,7 +13,7 @@
     {% set params = params|merge( { "class": embedParams.class } ) %}
 {% endif %}
 
-{{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
+{{ ez_http_tag_relation_location_ids([embedParams.id]) }}
 {{
     render(
         controller(

--- a/src/bundle/Resources/views/RichText/embed/location_inline_denied.html.twig
+++ b/src/bundle/Resources/views/RichText/embed/location_inline_denied.html.twig
@@ -1,2 +1,2 @@
-{{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
+{{ ez_http_tag_relation_location_ids([embedParams.id]) }}
 [[ Location #{{ embedParams.id }}: You do not have permission to view this Location ]]


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31673](https://jira.ez.no/browse/EZP-31673)
| **Bug**  | yes
| **New feature**    | no
| **Target version** | latest stable for bug fixes, master for new features
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

Update to use new cache functions.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
