### PR TITLE
EZP-30366: Use full width for custom tags in Online Editor

### DIFF
--- a/src/bundle/Resources/public/scss/_custom-tag.scss
+++ b/src/bundle/Resources/public/scss/_custom-tag.scss
@@ -1,5 +1,5 @@
 .ez-custom-tag {
-    max-width: 50%;
+    max-width: 100%;
     border: calculateRem(1px) solid $ez-custom-tag-color-border;
     margin: calculateRem(16px) 0;
     border-radius: calculateRem(5px);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30366](https://jira.ez.no/browse/EZP-30366)
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | 2.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Make custom tag blocks full-width in the Online Editor

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
