### PR TITLE
[Composer] Bumped Kernel version to ^7.5.11@dev to test on 7.5.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ext-dom": "*",
         "ext-libxml": "*",
         "symfony/symfony": "^3.4",
-        "ezsystems/ezpublish-kernel": "^7.4@dev",
+        "ezsystems/ezpublish-kernel": "^7.5.11@dev",
         "ezsystems/repository-forms": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Seems the Kernel version is quite outdated making RichText use latest release rather than stable 7.5

### Checklist
- [x] Travis CI passes