### PR TITLE
EZP-31933: Fixed custom tag link edit

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-linkedit.js
@@ -473,9 +473,9 @@ export default class EzBtnLinkEdit extends Component {
             this.invokeWithFixedScrollbar(() => {
                 editor.fire('actionPerformed', this);
 
-                const pathElement = editor.elementPath().lastElement;
-                if (pathElement.getName() === 'br') {
-                    const parent = pathElement.getParent();
+                const path = editor.elementPath();
+                if (path && path.lastElement.getName() === 'br') {
+                    const parent = path.lastElement.getParent();
                     if (parent.getName() === 'td' || parent.getName() === 'th') {
                         editor.eZ.moveCaretToElement(editor, parent);
                     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31933](https://jira.ez.no/browse/EZP-31933)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.1`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**Steps to reproduce**
1. Open any RichText field in Online Editor
2. Remove all the field content
3. Insert any custom tag
4. Make sure there are no empty paragraphs before and after the inserted custom tag
5. Edit the custom tag
6. Insert a "test" text
7. Make the inserted text a link
8. Chose any location for the link
9. Click the "Save" link button

**Expected result**
The link within the custom tag is updated.

**Actual result**
The link is updated, but Online Editor breaks because of the following JavaScript error:
```
react-dom.production.min.js:61 Uncaught TypeError: Cannot read property 'lastElement' of null
```

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
