### PR TITLE
EZP-31954: add missed validation error target

### DIFF
--- a/src/lib/eZ/FieldType/RichText/Type.php
+++ b/src/lib/eZ/FieldType/RichText/Type.php
@@ -159,7 +159,7 @@ class Type extends FieldType
     public function validate(FieldDefinition $fieldDefinition, SPIValue $value)
     {
         return array_map(function ($error) {
-            return new ValidationError("Validation of XML content failed:\n" . $error);
+            return new ValidationError("Validation of XML content failed:\n" . $error, null, [], 'xml');
         }, $this->inputHandler->validate($value->xml));
     }
 

--- a/tests/lib/eZ/FieldType/RichTextTest.php
+++ b/tests/lib/eZ/FieldType/RichTextTest.php
@@ -192,7 +192,10 @@ class RichTextTest extends TestCase
                 [
                     new ValidationError(
                         "Validation of XML content failed:\n" .
-                        'Error in 3:0: Element section has extra content: h1'
+                        'Error in 3:0: Element section has extra content: h1',
+                        null,
+                        [],
+                        'xml'
                     ),
                 ],
             ],
@@ -204,7 +207,10 @@ class RichTextTest extends TestCase
                 [
                     new ValidationError(
                         "Validation of XML content failed:\n" .
-                        "/*[local-name()='section' and namespace-uri()='http://docbook.org/ns/docbook']: The root element must have a version attribute."
+                        "/*[local-name()='section' and namespace-uri()='http://docbook.org/ns/docbook']: The root element must have a version attribute.",
+                        null,
+                        [],
+                        'xml'
                     ),
                 ],
             ],
@@ -216,7 +222,10 @@ class RichTextTest extends TestCase
                 [
                     new ValidationError(
                         "Validation of XML content failed:\n" .
-                        '/section/para/link: using scripts in links is not allowed'
+                        '/section/para/link: using scripts in links is not allowed',
+                        null,
+                        [],
+                        'xml'
                     ),
                 ],
             ],
@@ -228,7 +237,10 @@ class RichTextTest extends TestCase
                 [
                     new ValidationError(
                         "Validation of XML content failed:\n" .
-                        '/section/para/link: using scripts in links is not allowed'
+                        '/section/para/link: using scripts in links is not allowed',
+                        null,
+                        [],
+                        'xml'
                     ),
                 ],
             ],


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31954](https://jira.ez.no/browse/EZP-31954)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 1.0
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This is a part of issue with RichText XML validation fails,  where fatal error displayed:

> Argument 2 passed to Symfony\Component\Validator\Util\PropertyPath::append() must be of the type string, null given, called in /app/vendor/ezsystems/ezplatform-content-forms/src/lib/Validator/Constraints/FieldValueValidator.php on line 92 [in vendor/symfony/validator/Util/PropertyPath.php:34]`

see https://github.com/ezsystems/ezplatform-content-forms/pull/34
I see similar is done for Float field type
https://github.com/ezsystems/ezpublish-kernel/blob/7.5/eZ/Publish/Core/FieldType/Float/Type.php#L125

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
