### PR TITLE
EZP-31231: Fixed storing align and anchor attributes for custom styles

### DIFF
--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -123,6 +123,7 @@ class Template extends Render implements Converter
      *     attribute => param,
      *     ...
      * ].
+     *
      * @return string[]
      */
     protected function getAttributesMap(): array

--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -123,6 +123,7 @@ class Template extends Render implements Converter
      *     attribute => param,
      *     ...
      * ].
+     * @return string[]
      */
     protected function getAttributesMap(): array
     {

--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -97,8 +97,12 @@ class Template extends Render implements Converter
         }
         $parameters['content'] = !empty($innerContent) ? $innerContent : null;
 
-        if ($template->hasAttribute('ezxhtml:align')) {
-            $parameters['align'] = $template->getAttribute('ezxhtml:align');
+        if ($template->hasAttribute('ezxhtml:textalign')) {
+            $parameters['align'] = $template->getAttribute('ezxhtml:textalign');
+        }
+
+        if ($template->hasAttribute('xml:id')) {
+            $parameters['id'] = $template->getAttribute('xml:id');
         }
 
         $content = $this->renderer->renderTemplate(

--- a/src/lib/eZ/RichText/Converter/Render/Template.php
+++ b/src/lib/eZ/RichText/Converter/Render/Template.php
@@ -97,12 +97,10 @@ class Template extends Render implements Converter
         }
         $parameters['content'] = !empty($innerContent) ? $innerContent : null;
 
-        if ($template->hasAttribute('ezxhtml:textalign')) {
-            $parameters['align'] = $template->getAttribute('ezxhtml:textalign');
-        }
-
-        if ($template->hasAttribute('xml:id')) {
-            $parameters['id'] = $template->getAttribute('xml:id');
+        foreach ($this->getAttributesMap() as $attribute => $param) {
+            if ($template->hasAttribute($attribute)) {
+                $parameters[$param] = $template->getAttribute($attribute);
+            }
         }
 
         $content = $this->renderer->renderTemplate(
@@ -117,6 +115,21 @@ class Template extends Render implements Converter
             $payload->appendChild($document->createCDATASection($content));
             $template->appendChild($payload);
         }
+    }
+
+    /**
+     * Provides attributes map in format:
+     * [
+     *     attribute => param,
+     *     ...
+     * ].
+     */
+    protected function getAttributesMap(): array
+    {
+        return [
+            'ezxhtml:align' => 'align',
+            'xml:id' => 'id',
+        ];
     }
 
     /**

--- a/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -617,7 +617,7 @@
     </define>
     <define name="ez.template.attributes">
       <optional>
-        <ref name="ez.xhtml.textalign"/>
+        <ref name="ez.xhtml.align"/>
       </optional>
       <optional>
         <ref name="db.xml.id.attribute"/>

--- a/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -617,7 +617,10 @@
     </define>
     <define name="ez.template.attributes">
       <optional>
-        <ref name="ez.xhtml.align"/>
+        <ref name="ez.xhtml.textalign"/>
+      </optional>
+      <optional>
+        <ref name="db.xml.id.attribute"/>
       </optional>
       <ref name="ez.template.attributes.inline"/>
     </define>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:docbook="http://docbook.org/ns/docbook"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
-    xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
-    exclude-result-prefixes="docbook xlink ezxhtml ezcustom"
-    version="1.0">
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:docbook="http://docbook.org/ns/docbook"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+        exclude-result-prefixes="docbook xlink ezxhtml ezcustom"
+        version="1.0">
   <xsl:output indent="yes" encoding="UTF-8"/>
   <xsl:variable name="outputNamespace" select="''"/>
 
@@ -688,9 +688,14 @@
         <xsl:value-of select="@ezxhtml:class"/>
       </xsl:attribute>
     </xsl:if>
-    <xsl:if test="@ezxhtml:align">
-      <xsl:attribute name="data-ezalign">
-        <xsl:value-of select="@ezxhtml:align"/>
+    <xsl:if test="@xml:id">
+      <xsl:attribute name="id">
+        <xsl:value-of select="@xml:id"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="@ezxhtml:textalign">
+      <xsl:attribute name="style">
+        <xsl:value-of select="concat( 'text-align:', @ezxhtml:textalign, ';' )"/>
       </xsl:attribute>
     </xsl:if>
   </xsl:template>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -693,12 +693,12 @@
         <xsl:value-of select="@xml:id"/>
       </xsl:attribute>
     </xsl:if>
-    <xsl:if test="@ezxhtml:align and not(contains( @ezxhtml:class, 'ez-custom-tag' ))">
+    <xsl:if test="@ezxhtml:align and @type='style'">
       <xsl:attribute name="style">
         <xsl:value-of select="concat( 'text-align:', @ezxhtml:align, ';' )"/>
       </xsl:attribute>
     </xsl:if>
-    <xsl:if test="@ezxhtml:align and contains( @ezxhtml:class, 'ez-custom-tag' )">
+    <xsl:if test="@ezxhtml:align and not(@type='style')">
       <xsl:attribute name="data-ezalign">
         <xsl:value-of select="@ezxhtml:align"/>
       </xsl:attribute>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet
-        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-        xmlns:docbook="http://docbook.org/ns/docbook"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
-        xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
-        exclude-result-prefixes="docbook xlink ezxhtml ezcustom"
-        version="1.0">
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:docbook="http://docbook.org/ns/docbook"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+    xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+    exclude-result-prefixes="docbook xlink ezxhtml ezcustom"
+    version="1.0">
   <xsl:output indent="yes" encoding="UTF-8"/>
   <xsl:variable name="outputNamespace" select="''"/>
 

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -693,9 +693,9 @@
         <xsl:value-of select="@xml:id"/>
       </xsl:attribute>
     </xsl:if>
-    <xsl:if test="@ezxhtml:textalign">
+    <xsl:if test="@ezxhtml:align">
       <xsl:attribute name="style">
-        <xsl:value-of select="concat( 'text-align:', @ezxhtml:textalign, ';' )"/>
+        <xsl:value-of select="concat( 'text-align:', @ezxhtml:align, ';' )"/>
       </xsl:attribute>
     </xsl:if>
   </xsl:template>

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -693,9 +693,14 @@
         <xsl:value-of select="@xml:id"/>
       </xsl:attribute>
     </xsl:if>
-    <xsl:if test="@ezxhtml:align">
+    <xsl:if test="@ezxhtml:align and not(contains( @ezxhtml:class, 'ez-custom-tag' ))">
       <xsl:attribute name="style">
         <xsl:value-of select="concat( 'text-align:', @ezxhtml:align, ';' )"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="@ezxhtml:align and contains( @ezxhtml:class, 'ez-custom-tag' )">
+      <xsl:attribute name="data-ezalign">
+        <xsl:value-of select="@ezxhtml:align"/>
       </xsl:attribute>
     </xsl:if>
   </xsl:template>

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet
-        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-        xmlns:ezxhtml5="http://ez.no/namespaces/ezpublish5/xhtml5/edit"
-        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
-        xmlns:xlink="http://www.w3.org/1999/xlink"
-        xmlns="http://docbook.org/ns/docbook"
-        exclude-result-prefixes="ezxhtml5"
-        version="1.0">
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:ezxhtml5="http://ez.no/namespaces/ezpublish5/xhtml5/edit"
+    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns="http://docbook.org/ns/docbook"
+    exclude-result-prefixes="ezxhtml5"
+    version="1.0">
   <xsl:output indent="yes" encoding="UTF-8"/>
 
   <xsl:template match="/ezxhtml5:section">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -735,7 +735,7 @@
           </xsl:call-template>
         </xsl:variable>
         <xsl:if test="$textAlign != ''">
-          <xsl:attribute name="ezxhtml:textalign">
+          <xsl:attribute name="ezxhtml:align">
             <xsl:value-of select="$textAlign"/>
           </xsl:attribute>
         </xsl:if>

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -740,6 +740,11 @@
           </xsl:attribute>
         </xsl:if>
       </xsl:if>
+      <xsl:if test="@data-ezalign">
+        <xsl:attribute name="ezxhtml:align">
+          <xsl:value-of select="@data-ezalign"/>
+        </xsl:attribute>
+      </xsl:if>
       <xsl:choose>
         <!-- Nest content of Style tag in ezcontent -->
         <xsl:when test="@data-eztype='style'">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:ezxhtml5="http://ez.no/namespaces/ezpublish5/xhtml5/edit"
-    xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns="http://docbook.org/ns/docbook"
-    exclude-result-prefixes="ezxhtml5"
-    version="1.0">
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:ezxhtml5="http://ez.no/namespaces/ezpublish5/xhtml5/edit"
+        xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns="http://docbook.org/ns/docbook"
+        exclude-result-prefixes="ezxhtml5"
+        version="1.0">
   <xsl:output indent="yes" encoding="UTF-8"/>
 
   <xsl:template match="/ezxhtml5:section">
@@ -722,10 +722,23 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="@data-ezalign">
-        <xsl:attribute name="ezxhtml:align">
-          <xsl:value-of select="@data-ezalign"/>
+      <xsl:if test="@id">
+        <xsl:attribute name="xml:id">
+          <xsl:value-of select="@id"/>
         </xsl:attribute>
+      </xsl:if>
+      <xsl:if test="contains( @style, 'text-align:' )">
+        <xsl:variable name="textAlign">
+          <xsl:call-template name="extractStyleValue">
+            <xsl:with-param name="style" select="@style"/>
+            <xsl:with-param name="property" select="'align'"/>
+          </xsl:call-template>
+        </xsl:variable>
+        <xsl:if test="$textAlign != ''">
+          <xsl:attribute name="ezxhtml:textalign">
+            <xsl:value-of select="$textAlign"/>
+          </xsl:attribute>
+        </xsl:if>
       </xsl:if>
       <xsl:choose>
         <!-- Nest content of Style tag in ezcontent -->

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -731,7 +731,7 @@
         <xsl:variable name="textAlign">
           <xsl:call-template name="extractStyleValue">
             <xsl:with-param name="style" select="@style"/>
-            <xsl:with-param name="property" select="'align'"/>
+            <xsl:with-param name="property" select="'text-align'"/>
           </xsl:call-template>
         </xsl:variable>
         <xsl:if test="$textAlign != ''">

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/034-nestedTemplate.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/034-nestedTemplate.xml
@@ -4,7 +4,7 @@
          xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
          xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
          version="5.0-variant ezpublish-1.0">
-  <eztemplate name="factbox" ezxhtml:class="templateClass ez-custom-tag" ezxhtml:align="left" xml:id="template">
+  <eztemplate name="factbox" ezxhtml:class="templateClass" ezxhtml:align="left" xml:id="template">
     <ezcontent>
       <eztemplate name="externalimage" ezxhtml:class="templateClass2" ezxhtml:align="right" xml:id="nested-template">
         <ezconfig>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/034-nestedTemplate.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/034-nestedTemplate.xml
@@ -4,9 +4,9 @@
          xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
          xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
          version="5.0-variant ezpublish-1.0">
-  <eztemplate name="factbox" ezxhtml:class="templateClass" ezxhtml:align="left">
+  <eztemplate name="factbox" ezxhtml:class="templateClass" ezxhtml:align="left" xml:id="template">
     <ezcontent>
-      <eztemplate name="externalimage" ezxhtml:class="templateClass2" ezxhtml:align="right">
+      <eztemplate name="externalimage" ezxhtml:class="templateClass2" ezxhtml:align="right" xml:id="nested-template">
         <ezconfig>
           <ezvalue key="src">
             http://upload.wikimedia.org/wikipedia/commons/c/c6/R-S_mk2.gif

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/034-nestedTemplate.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/034-nestedTemplate.xml
@@ -4,7 +4,7 @@
          xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
          xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
          version="5.0-variant ezpublish-1.0">
-  <eztemplate name="factbox" ezxhtml:class="templateClass" ezxhtml:align="left" xml:id="template">
+  <eztemplate name="factbox" ezxhtml:class="templateClass ez-custom-tag" ezxhtml:align="left" xml:id="template">
     <ezcontent>
       <eztemplate name="externalimage" ezxhtml:class="templateClass2" ezxhtml:align="right" xml:id="nested-template">
         <ezconfig>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/024-template.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/024-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass" style="text-align:left;">
+  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass" data-ezalign="left">
     <div data-ezelement="ezcontent">
       <table title="tableTitle">
         <caption>About factoids</caption>
@@ -27,7 +27,7 @@
       <span data-ezelement="ezvalue" data-ezvalue-key="title">Factoids</span>
     </span>
   </div>
-  <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2" style="text-align:right;">
+  <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2" data-ezalign="right">
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="src">http://upload.wikimedia.org/wikipedia/commons/c/c6/R-S_mk2.gif</span>
       <span data-ezelement="ezvalue" data-ezvalue-key="height">365</span>
@@ -36,8 +36,8 @@
       <span data-ezelement="ezvalue" data-ezvalue-key="caption">bistable multivibrator</span>
     </span>
   </div>
-  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass3" style="text-align:center;">
+  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass3" data-ezalign="center">
     <div data-ezelement="ezcontent">It is widely known that the bistable multivibrator hums z's in the middle octave key of E.</div>
   </div>
-  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass4" style="text-align:center;"/>
+  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass4" data-ezalign="center"/>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/024-template.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/024-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass" data-ezalign="left">
+  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass" style="text-align:left;">
     <div data-ezelement="ezcontent">
       <table title="tableTitle">
         <caption>About factoids</caption>
@@ -27,7 +27,7 @@
       <span data-ezelement="ezvalue" data-ezvalue-key="title">Factoids</span>
     </span>
   </div>
-  <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2" data-ezalign="right">
+  <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2" style="text-align:right;">
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="src">http://upload.wikimedia.org/wikipedia/commons/c/c6/R-S_mk2.gif</span>
       <span data-ezelement="ezvalue" data-ezvalue-key="height">365</span>
@@ -36,8 +36,8 @@
       <span data-ezelement="ezvalue" data-ezvalue-key="caption">bistable multivibrator</span>
     </span>
   </div>
-  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass3" data-ezalign="center">
+  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass3" style="text-align:center;">
     <div data-ezelement="ezcontent">It is widely known that the bistable multivibrator hums z's in the middle octave key of E.</div>
   </div>
-  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass4" data-ezalign="center"/>
+  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass4" style="text-align:center;"/>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/031-ezstyle.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/031-ezstyle.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-    <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" data-ezalign="left">Highlighted block with "left" align.</div>
-    <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" data-ezalign="right">Highlighted block with "right" align.</div>
-    <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" data-ezalign="center">Highlighted block with "center" align.</div>
+    <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" style="text-align:left;">Highlighted block with "left" align.</div>
+    <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" style="text-align:right;">Highlighted block with "right" align.</div>
+    <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block" style="text-align:center;">Highlighted block with "center" align.</div>
     <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block">Highlighted block with multiple lines<br/>Highlighted block with multiple lines<br/>Highlighted block with multiple lines</div>
     <div data-ezelement="eztemplate" data-eztype="style" data-ezname="highlighted_block">Highlighted block with multiple lines and emphasis<br/><strong>Highlighted block with multiple lines and emphasis</strong><br/>Highlighted block with multiple lines and emphasis</div>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/034-nestedTemplate.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/034-nestedTemplate.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass ez-custom-tag" id="template" data-ezalign="left">
+  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass" id="template" data-ezalign="left">
     <div data-ezelement="ezcontent">
-      <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2" style="text-align:right;" id="nested-template">
+      <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2" data-ezalign="right" id="nested-template">
         <span data-ezelement="ezconfig">
           <span data-ezelement="ezvalue" data-ezvalue-key="src">
             http://upload.wikimedia.org/wikipedia/commons/c/c6/R-S_mk2.gif

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/034-nestedTemplate.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/034-nestedTemplate.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass" id="template" style="text-align:left;">
+  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass ez-custom-tag" id="template" data-ezalign="left">
     <div data-ezelement="ezcontent">
-      <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2"
-           style="text-align:right;" id="nested-template">
+      <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2" style="text-align:right;" id="nested-template">
         <span data-ezelement="ezconfig">
           <span data-ezelement="ezvalue" data-ezvalue-key="src">
             http://upload.wikimedia.org/wikipedia/commons/c/c6/R-S_mk2.gif

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/034-nestedTemplate.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/034-nestedTemplate.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass" data-ezalign="left">
+  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass" id="template" style="text-align:left;">
     <div data-ezelement="ezcontent">
       <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2"
-           data-ezalign="right">
+           style="text-align:right;" id="nested-template">
         <span data-ezelement="ezconfig">
           <span data-ezelement="ezvalue" data-ezvalue-key="src">
             http://upload.wikimedia.org/wikipedia/commons/c/c6/R-S_mk2.gif

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/034-nestedTemplate.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/034-nestedTemplate.xml
@@ -20,9 +20,11 @@
           </param>
           <param name="content"/>
           <param name="align">right</param>
+          <param name="id">nested-template</param>
         </template-output>
       </section>
     </param>
     <param name="align">left</param>
+    <param name="id">template</param>
   </template-output>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-31231](https://jira.ez.no/browse/EZP-31231)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 1.1
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Align and anchor attributes were not storing and displaying properly when working with custom style, also additional option to render `id` attribute has been added in form of:

```
<h2 id="{{ id }}" style="text-align:{{ align }}; color:red">
    {{ content }}
</h2>
```

where the code above is some [custom style](https://doc.ezplatform.com/en/2.5/guide/extending/extending_online_editor/#custom-styles).

### QA
// maintainer update:
- Custom Tags and Styles share markup and codebase, so regressions should be checked for both of them.

**TODO**:
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
