### PR TITLE
EZP-32187: Fix RichText unresponsive after cancel editing of custom tag attributes

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-customtag-update.js
@@ -194,7 +194,7 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
                 <div className="ez-ae-custom-tag__footer">
                     <button
                         className="ez-btn-ae btn ez-btn-ae--cancel"
-                        onClick={this.props.cancelExclusive}
+                        onClick={this.cancelCustomTagEdit.bind(this)}
                     >
                         {cancelLabel}
                     </button>
@@ -247,6 +247,19 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
         Object.keys(this.attributes).forEach((key) => {
             widget.setConfig(key, configValues[key].value);
         });
+    }
+
+    /**
+     * Cancels the custom tag editing in AlloyEditor.
+     *
+     * @method cancelCustomTagEdit
+     */
+    cancelCustomTagEdit() {
+        const widget = this.getWidget() || this.widget;
+
+        widget.setFocused(true);
+
+        this.props.cancelExclusive();
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32187](https://issues.ibexa.co/browse/EZP-32187)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 3.1, 3.2
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**STR**:
On a clean install, edit any content with richtext field
Click "+" (Add) button on the left
Select "Facebook" tag (or any other)
Fill attributes and save
On the top bar, click "pencil" (edit) icon to edit custom tag attributes
Click "Cancel"
**AR**: Richtext fields editing unresponsive, error in console - "Cannot read property 'isAligned' of null"
**ER**: Attributes editing closed, and top bar displayed. The same as after "Save" button click.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
