### PR TITLE
EZP-32194: Disable embed-inline for table/table-row toolbars

### DIFF
--- a/src/bundle/Resources/config/prepend/ezpublish.yaml
+++ b/src/bundle/Resources/config/prepend/ezpublish.yaml
@@ -298,13 +298,13 @@ system:
                     tr:
                         buttons:
                             ezmoveup:
-                                priority: 60
+                                priority: 70
                             ezmovedown:
-                                priority: 50
+                                priority: 60
                             ezattributesedit:
-                                priority: 40
+                                priority: 50
                             tableHeading:
-                                priority: 30
+                                priority: 40
                             ezanchor:
                                 priority: 20
                             eztableremove:
@@ -312,13 +312,13 @@ system:
                     table:
                         buttons:
                             ezmoveup:
-                                priority: 60
+                                priority: 70
                             ezmovedown:
-                                priority: 50
+                                priority: 60
                             ezattributesedit:
-                                priority: 40
+                                priority: 50
                             tableHeading:
-                                priority: 30
+                                priority: 40
                             ezanchor:
                                 priority: 20
                             eztableremove:

--- a/src/bundle/Resources/config/prepend/ezpublish.yaml
+++ b/src/bundle/Resources/config/prepend/ezpublish.yaml
@@ -298,14 +298,12 @@ system:
                     tr:
                         buttons:
                             ezmoveup:
-                                priority: 70
-                            ezmovedown:
                                 priority: 60
-                            ezattributesedit:
+                            ezmovedown:
                                 priority: 50
-                            tableHeading:
+                            ezattributesedit:
                                 priority: 40
-                            ezembedinline:
+                            tableHeading:
                                 priority: 30
                             ezanchor:
                                 priority: 20
@@ -314,14 +312,12 @@ system:
                     table:
                         buttons:
                             ezmoveup:
-                                priority: 70
-                            ezmovedown:
                                 priority: 60
-                            ezattributesedit:
+                            ezmovedown:
                                 priority: 50
-                            tableHeading:
+                            ezattributesedit:
                                 priority: 40
-                            ezembedinline:
+                            tableHeading:
                                 priority: 30
                             ezanchor:
                                 priority: 20


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32194](https://jira.ez.no/browse/EZP-32194)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 2.2
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

There is no reason to have an "embed-inline" button in the "table" and "table-row" toolbars.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
