### PR TITLE
EZP-32340: Deprecated ezpublish_rest.field_type_processor in favour of ibexa.rest.field_type.processor

### DIFF
--- a/src/bundle/Resources/config/rest.yaml
+++ b/src/bundle/Resources/config/rest.yaml
@@ -8,4 +8,4 @@ services:
         arguments:
             - '@ezrichtext.converter.edit.xhtml5'
         tags:
-            - { name: ezplatform.field_type.rest.processor, alias: ezrichtext }
+            - { name: ibexa.rest.field_type.processor, alias: ezrichtext }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32340](https://jira.ez.no/browse/EZP-32340)
| **Type**| improvement
| **Target version** | `3.2`+
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Deprecated `ezpublish_rest.field_type_processor` in favour of `ezplatform.field_type.rest.processor`.

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
