### PR TITLE
EZP-32351: Custom tags' switch between attributes and content is missing an icon

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/plugins/base/ez-custom-tag-base.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/plugins/base/ez-custom-tag-base.js
@@ -144,12 +144,12 @@ const customTagBaseDefinition = {
                 <div class="ez-custom-tag__header-btns">
                     <button class="btn ez-custom-tag__header-btn ez-custom-tag__header-btn--attributes" data-target="attributes">
                         <svg class="ez-icon ez-icon--small">
-                            <use xlink:href={window.eZ.helpers.icon.getIconPath('list')}></use>
+                            <use xlink:href=${window.eZ.helpers.icon.getIconPath('list')}></use>
                         </svg>
                     </button>
                     <button class="btn ez-custom-tag__header-btn ez-custom-tag__header-btn--content" data-target="content">
                         <svg class="ez-icon ez-icon--small">
-                            <use xlink:href={window.eZ.helpers.icon.getIconPath('edit')}></use>
+                            <use xlink:href=${window.eZ.helpers.icon.getIconPath('edit')}></use>
                         </svg>
                     </button>
                 </div>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32351](https://jira.ez.no/browse/EZP-32351)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.2`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

>In custom tags, there are no icons for switch between attributes and content.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] ~Implement tests.~
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
