### PR TITLE
EZP-32400: Fixed displaying anchors for tables

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/core/base-richtext.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/core/base-richtext.js
@@ -156,7 +156,7 @@
             const elementPreviousSibling = element.previousSibling;
             const isTableWithAnchor =
                 element.tagName.toLowerCase() === TABLE_TAG_NAME &&
-                elementPreviousSibling.tagName.toLowerCase() === SVG_TAG_NAME;
+                elementPreviousSibling?.tagName.toLowerCase() === SVG_TAG_NAME;
 
             if (isTableWithAnchor) {
                 elementPreviousSibling.remove();

--- a/src/bundle/Resources/public/js/OnlineEditor/core/base-richtext.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/core/base-richtext.js
@@ -1,4 +1,6 @@
 (function(global, doc, eZ, CKEDITOR, AlloyEditor) {
+    const TABLE_TAG_NAME = 'table';
+    const SVG_TAG_NAME = 'svg';
     const HTML_NODE = 1;
     const TEXT_NODE = 3;
     const notInitializeElements = ['strong', 'em', 'u', 'sup', 'sub', 's'];
@@ -151,8 +153,14 @@
 
         clearAnchor(element) {
             const icon = element.querySelector('.ez-icon--anchor');
+            const elementPreviousSibling = element.previousSibling;
+            const isTableWithAnchor =
+                element.tagName.toLowerCase() === TABLE_TAG_NAME &&
+                elementPreviousSibling.tagName.toLowerCase() === SVG_TAG_NAME;
 
-            if (icon) {
+            if (isTableWithAnchor) {
+                elementPreviousSibling.remove();
+            } else if (icon) {
                 icon.remove();
             } else {
                 element.classList.remove('ez-has-anchor');
@@ -163,7 +171,7 @@
             const container = doc.createElement('div');
             const icon = `
                 <svg class="ez-icon ez-icon--small ez-icon--secondary ez-icon--anchor">
-                    <use xlink:href={window.eZ.helpers.icon.getIconPath('link-anchor')}></use>
+                    <use xlink:href=${window.eZ.helpers.icon.getIconPath('link-anchor')}></use>
                 </svg>`;
 
             container.insertAdjacentHTML('afterbegin', icon);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-32400](https://jira.ez.no/browse/EZP-32400)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.2`, `2.3`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Followup for https://github.com/ezsystems/ezplatform-admin-ui/pull/1745 targetting v3. Here, there is also a fix for the wrong anchor icon rendering.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
