### PR TITLE
IBX-284: Fixed line breaks inside links

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -229,6 +229,12 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="docbook:link[@xlink:href]/text()">
+    <xsl:call-template name="breakLine">
+      <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+
   <xsl:template match="docbook:link[@xlink:href]">
     <xsl:element name="a" namespace="{$outputNamespace}">
       <xsl:attribute name="href">

--- a/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -229,6 +229,12 @@
     </xsl:element>
   </xsl:template>
 
+  <xsl:template match="docbook:link[@xlink:href]/text()">
+    <xsl:call-template name="breakLine">
+      <xsl:with-param name="text" select="."/>
+    </xsl:call-template>
+  </xsl:template>
+
   <xsl:template match="docbook:link[@xlink:href]">
     <xsl:choose>
       <xsl:when test="@xlink:href != '#'">

--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -259,7 +259,9 @@
         </xsl:attribute>
       </xsl:if>
       <xsl:call-template name="ezattribute"/>
-      <xsl:apply-templates/>
+      <xsl:call-template name="breakline">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
     </link>
   </xsl:template>
 

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/014-link.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/docbook/014-link.xml
@@ -21,13 +21,17 @@
     <link xlink:href="ezcontent://333" xlink:show="none" xml:id="id5" xlink:title="Content title" ezxhtml:class="linkClass5">Content name</link>
   </para>
   <para>
-    <link xlink:href="ezcontent://333" xlink:show="none" xml:id="id6" xlink:title="Content title" ezxhtml:class="linkClass5">
+    <link xlink:href="ezcontent://333" xlink:show="none" xml:id="id6" xlink:title="Content title" ezxhtml:class="linkClass6">
       <ezattribute>
         <ezvalue key="name-1">value 1</ezvalue>
         <ezvalue key="name-2">value 2</ezvalue>
-      </ezattribute>
-      Content name
-    </link>
+      </ezattribute>Content name</link>
+  </para>
+  <para>
+    <literallayout class="normal">
+      <link xlink:href="ezcontent://444" xlink:show="none" xml:id="id7" xlink:title="Content title" ezxhtml:class="linkClass7">Content name
+with some line break</link>
+    </literallayout>
   </para>
   <para><anchor xml:id="anchor"/>Some anchored content.</para>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/014-link.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/014-link.xml
@@ -17,9 +17,10 @@
     <a href="ezcontent://333" id="id5" title="Content title" class="linkClass5">Content name</a>
   </p>
   <p>
-    <a href="ezcontent://333" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" id="id6" title="Content title" class="linkClass5">
-      Content name
-    </a>
+    <a href="ezcontent://333" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" id="id6" title="Content title" class="linkClass6">Content name</a>
+  </p>
+  <p>
+    <a href="ezcontent://444" id="id7" title="Content title" class="linkClass7">Content name<br/>with some line break</a>
   </p>
   <p><a id="anchor"/>Some anchored content.</p>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/014-link.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/output/014-link.xml
@@ -17,9 +17,10 @@
     <a href="ezcontent://333" id="id5" title="Content title" class="linkClass5">Content name</a>
   </p>
   <p>
-    <a href="ezcontent://333" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" id="id6" title="Content title" class="linkClass5">
-      Content name
-    </a>
+    <a href="ezcontent://333" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" id="id6" title="Content title" class="linkClass6">Content name</a>
+  </p>
+  <p>
+    <a href="ezcontent://444" id="id7" title="Content title" class="linkClass7">Content name<br/>with some line break</a>
   </p>
   <p><a id="anchor"/>Some anchored content.</p>
 </section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-284](https://issues.ibexa.co/browse/IBX-284)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `1.1`, `2.2`, `2.3`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Soft line breaks are not properly interpreted when inserted in links. This PR aims to add proper usage of `breakline` template, as in other cases.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
