### PR TITLE
IBX-707: Improved RichTextConverterExtension libxml-related error handling

### DIFF
--- a/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
+++ b/src/bundle/Templating/Twig/Extension/RichTextConverterExtension.php
@@ -59,7 +59,7 @@ class RichTextConverterExtension extends AbstractExtension
      */
     public function richTextToHtml5(DOMDocument $xmlData): string
     {
-        return $this->richTextOutputConverter->convert($xmlData)->saveHTML();
+        return $this->richTextOutputConverter->convert($xmlData)->saveHTML() ?: '';
     }
 
     /**
@@ -71,6 +71,6 @@ class RichTextConverterExtension extends AbstractExtension
      */
     public function richTextToHtml5Edit(DOMDocument $xmlData): string
     {
-        return $this->richTextEditConverter->convert($xmlData)->saveHTML();
+        return $this->richTextEditConverter->convert($xmlData)->saveHTML() ?: '';
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-707](https://issues.ibexa.co/browse/IBX-707)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.3`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Given `saveHTML` method might return false in case of external errors/libxml flaws, we should introduce more bulletproof checks for returned values. Error logging doesn't seem to be needed, as the converter will throw an exception in case of any libxml errors anyway, ref: https://github.com/ezsystems/ezplatform-richtext/blob/68e21b4be1477c09bb1a5cf0e2a9fae648a42b69/src/lib/eZ/RichText/Converter/Xslt.php#L140


**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
