### PR TITLE
IBX-759: Fixed wrong class taken to calculate toolbar's width

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/toolbars/config/base.js
@@ -42,7 +42,7 @@ export default class EzConfigBase extends EzConfigButtonsBase {
             const scrollLeft = parseInt(block.$.scrollLeft, 10);
             const blockLeftMargin = block.$.offsetLeft;
             const blockWidth = block.$.offsetWidth;
-            const toolbarWidth = document.querySelector('.ae-toolbar-floating').offsetWidth;
+            const toolbarWidth = document.querySelector('.ae-toolbar-styles').offsetWidth;
             const maxLeft = blockWidth - toolbarWidth;
 
             range.selectNodeContents(positionReference.$);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-759](https://issues.ibexa.co/browse/IBX-759)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.3`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently, there is a wrong class specified when calculating the toolbar's width. That results in JS errors when it changes. Went for `.ae-toolbar-styles` as it seems to be a generic class shared between all the affected toolbars.

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
