### PR TITLE
IBX-962: New custom tag inserting

### DIFF
--- a/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-customtag-update.js
+++ b/src/bundle/Resources/public/js/OnlineEditor/buttons/ez-btn-customtag-update.js
@@ -248,7 +248,9 @@ export default class EzBtnCustomTagUpdate extends EzWidgetButton {
     cancelCustomTagEdit() {
         const widget = this.getWidget() || this.widget;
 
-        widget.setFocused(true);
+        if (widget) {
+            widget.setFocused(true);
+        }
 
         this.props.cancelExclusive();
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-962](https://jira.ez.no/browse/IBX-962)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `2.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

**Steps to reproduce:**
1. Create a new content item with RichText field
2. Try to insert Facebook (or any other) custom tag into the RichText field
3. On the custom tag attributes screen click the "Cancel" link

**Expected result**
Insert custom tag dialog is closed.

**Actual result**
Insert custom tag dialog stays on the screen and the following JavaScript error is thrown:
```
react-dom.production.min.js:32 Uncaught TypeError: Cannot read property 'setFocused' of null at ButtonCustomTagUpdate.cancelCustomTagEdit
```


**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
