### PR TITLE
[Travis] Updated to Focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 services:
   - mysql
 
-#A Mysql isn't installed on trusty (only client is), so we need to specifically install it
+# Mysql isn't installed on trusty (only client is), so we need to specifically install it
 addons:
   apt:
     packages:
@@ -28,7 +28,7 @@ branches:
 matrix:
   fast_finish: true
   include:
-#A 7.1
+# 7.1
     - name: '[PHP 7.1] Unit tests'
       php: 7.1
       env: TEST_CONFIG="phpunit.xml"
@@ -38,7 +38,7 @@ matrix:
         - TEST_CONFIG="phpunit-integration-legacy.xml"
         - DB="mysql"
         - DATABASE="mysql://root@localhost/testdb"
-#A 7.2
+# 7.2
     - name: '[PHP 7.2] Unit tests'
       php: 7.2
       env: TEST_CONFIG="phpunit.xml"
@@ -62,20 +62,20 @@ matrix:
         - BEHAT_OPTS="--profile=adminui --suite=richtext"
         - SYMFONY_ENV=behat
         - SYMFONY_DEBUG=1
-#A 7.3
+# 7.3
     - name: '[PHP 7.3] Unit tests'
       php: 7.3
       env: TEST_CONFIG="phpunit.xml"
-#A CS check
+# CS check
     - name: 'Code Style Check'
       php: 7.2
       env: CHECK_CS=true
 
-#A reduce depth (history) of git checkout
+# reduce depth (history) of git checkout
 git:
   depth: 30
 
-#A disable mail notifications
+# disable mail notifications
 notifications:
   email: false
   slack:
@@ -85,41 +85,41 @@ notifications:
     on_failure: always
     on_pull_requests: false
 
-#A setup requirements for running unit/integration/behat tests
+# setup requirements for running unit/integration/behat tests
 before_install:
-  #A Disable xdebug to speed things up as we don't currently generate coverage on travis
+  # Disable xdebug to speed things up as we don't currently generate coverage on travis
   - phpenv config-rm xdebug.ini
-  #A Disable expired certificate
+  # Disable expired certificate
   - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
-  #A Add custom php.ini configuration for test matrix
+  # Add custom php.ini configuration for test matrix
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo "default_charset=UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  #A Detecting timezone issues by testing on random timezone
+  # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
 
 install:
-  #A Prepare system
+  # Prepare system
   - ./bin/.travis/prepare_unittest.sh
   - travis_retry composer install --no-progress --no-interaction --prefer-dist --no-suggest
-  #A Setup Solr / Elastic search if asked for
+  # Setup Solr / Elastic search if asked for
   - if [ "${TEST_CONFIG}" = "phpunit-integration-legacy-elasticsearch.xml" ] ; then ./bin/.travis/init_elasticsearch.sh ; fi
   - if [ "${TEST_CONFIG}" = "phpunit-integration-legacy-solr.xml" ] ; then ./vendor/ezsystems/ezplatform-solr-search-engine/bin/.travis/init_solr.sh; fi
-  #A Prepare Behat environment if needed
+  # Prepare Behat environment if needed
   - if [ "${BEHAT_OPTS}" != "" ]; then ./bin/.travis/prepare_ezplatform.sh ; fi
 
-#A execute phpunit or behat as the script command
+# execute phpunit or behat as the script command
 script:
   - if [ "${TEST_CONFIG}" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE ./vendor/bin/phpunit -c $TEST_CONFIG ; fi
   - if [ "${CHECK_CS}" = "true" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating; fi
   - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS" ; fi
 
 after_failure:
-  #A Will show us the last bit of the log of container's main processes
-  #A (not counting shell process above running php and behat)
-  #A NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
+  # Will show us the last bit of the log of container's main processes
+  # (not counting shell process above running php and behat)
+  # NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
   - docker-compose --env-file=.env logs -t --tail=15
-  #A Will show us what is up, and how long it's been up
+  # Will show us what is up, and how long it's been up
   - docker ps -s
 after_script:
   - if [ "${BEHAT_OPTS}" != "" ] ; then bin/ezreport ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: trusty
 language: php
 
 env:
@@ -112,13 +112,13 @@ install:
 script:
   - if [ "${TEST_CONFIG}" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE ./vendor/bin/phpunit -c $TEST_CONFIG ; fi
   - if [ "${CHECK_CS}" = "true" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating; fi
-  - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS" ; fi
+  - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS" ; fi
 
 after_failure:
   # Will show us the last bit of the log of container's main processes
   # (not counting shell process above running php and behat)
   # NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
-  - docker-compose --env-file=.env logs -t --tail=15
+  - docker-compose logs -t --tail=15
   # Will show us what is up, and how long it's been up
   - docker ps -s
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: php
 
 env:
@@ -110,13 +110,13 @@ install:
 script:
   - if [ "${TEST_CONFIG}" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE ./vendor/bin/phpunit -c $TEST_CONFIG ; fi
   - if [ "${CHECK_CS}" = "true" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating; fi
-  - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS" ; fi
+  - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS" ; fi
 
 after_failure:
   # Will show us the last bit of the log of container's main processes
   # (not counting shell process above running php and behat)
   # NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
-  - docker-compose logs -t --tail=15
+  - docker-compose --env-file=.env logs -t --tail=15
   # Will show us what is up, and how long it's been up
   - docker ps -s
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,8 @@ notifications:
 before_install:
   # Disable xdebug to speed things up as we don't currently generate coverage on travis
   - phpenv config-rm xdebug.ini
+  # Disable expired certificate
+. - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
   # Add custom php.ini configuration for test matrix
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo "default_charset=UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: php
 
 env:
@@ -112,13 +112,13 @@ install:
 script:
   - if [ "${TEST_CONFIG}" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE ./vendor/bin/phpunit -c $TEST_CONFIG ; fi
   - if [ "${CHECK_CS}" = "true" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating; fi
-  - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS" ; fi
+  - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS" ; fi
 
 after_failure:
   # Will show us the last bit of the log of container's main processes
   # (not counting shell process above running php and behat)
   # NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
-  - docker-compose logs -t --tail=15
+  - docker-compose --env-file=.env logs -t --tail=15
   # Will show us what is up, and how long it's been up
   - docker ps -s
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ before_install:
   # Disable xdebug to speed things up as we don't currently generate coverage on travis
   - phpenv config-rm xdebug.ini
   # Disable expired certificate
-. - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
+  - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
   # Add custom php.ini configuration for test matrix
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo "default_charset=UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 services:
   - mysql
 
-# Mysql isn't installed on trusty (only client is), so we need to specifically install it
+#A Mysql isn't installed on trusty (only client is), so we need to specifically install it
 addons:
   apt:
     packages:
@@ -28,7 +28,7 @@ branches:
 matrix:
   fast_finish: true
   include:
-# 7.1
+#A 7.1
     - name: '[PHP 7.1] Unit tests'
       php: 7.1
       env: TEST_CONFIG="phpunit.xml"
@@ -38,7 +38,7 @@ matrix:
         - TEST_CONFIG="phpunit-integration-legacy.xml"
         - DB="mysql"
         - DATABASE="mysql://root@localhost/testdb"
-# 7.2
+#A 7.2
     - name: '[PHP 7.2] Unit tests'
       php: 7.2
       env: TEST_CONFIG="phpunit.xml"
@@ -62,20 +62,20 @@ matrix:
         - BEHAT_OPTS="--profile=adminui --suite=richtext"
         - SYMFONY_ENV=behat
         - SYMFONY_DEBUG=1
-# 7.3
+#A 7.3
     - name: '[PHP 7.3] Unit tests'
       php: 7.3
       env: TEST_CONFIG="phpunit.xml"
-# CS check
+#A CS check
     - name: 'Code Style Check'
       php: 7.2
       env: CHECK_CS=true
 
-# reduce depth (history) of git checkout
+#A reduce depth (history) of git checkout
 git:
   depth: 30
 
-# disable mail notifications
+#A disable mail notifications
 notifications:
   email: false
   slack:
@@ -85,41 +85,41 @@ notifications:
     on_failure: always
     on_pull_requests: false
 
-# setup requirements for running unit/integration/behat tests
+#A setup requirements for running unit/integration/behat tests
 before_install:
-  # Disable xdebug to speed things up as we don't currently generate coverage on travis
+  #A Disable xdebug to speed things up as we don't currently generate coverage on travis
   - phpenv config-rm xdebug.ini
-  # Disable expired certificate
+  #A Disable expired certificate
   - sed -i '/mozilla\/DST_Root_CA_X3.crt/ s/./!&/' /etc/ca-certificates.conf \ && update-ca-certificates --verbose
-  # Add custom php.ini configuration for test matrix
+  #A Add custom php.ini configuration for test matrix
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo "default_charset=UTF-8" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  # Detecting timezone issues by testing on random timezone
+  #A Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
 
 install:
-  # Prepare system
+  #A Prepare system
   - ./bin/.travis/prepare_unittest.sh
   - travis_retry composer install --no-progress --no-interaction --prefer-dist --no-suggest
-  # Setup Solr / Elastic search if asked for
+  #A Setup Solr / Elastic search if asked for
   - if [ "${TEST_CONFIG}" = "phpunit-integration-legacy-elasticsearch.xml" ] ; then ./bin/.travis/init_elasticsearch.sh ; fi
   - if [ "${TEST_CONFIG}" = "phpunit-integration-legacy-solr.xml" ] ; then ./vendor/ezsystems/ezplatform-solr-search-engine/bin/.travis/init_solr.sh; fi
-  # Prepare Behat environment if needed
+  #A Prepare Behat environment if needed
   - if [ "${BEHAT_OPTS}" != "" ]; then ./bin/.travis/prepare_ezplatform.sh ; fi
 
-# execute phpunit or behat as the script command
+#A execute phpunit or behat as the script command
 script:
   - if [ "${TEST_CONFIG}" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE ./vendor/bin/phpunit -c $TEST_CONFIG ; fi
   - if [ "${CHECK_CS}" = "true" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating; fi
   - if [ "${BEHAT_OPTS}" != "" ]; then cd "$HOME/build/ezplatform"; docker-compose --env-file=.env exec --user www-data app sh -c "./bin/ezbehat $BEHAT_OPTS" ; fi
 
 after_failure:
-  # Will show us the last bit of the log of container's main processes
-  # (not counting shell process above running php and behat)
-  # NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
+  #A Will show us the last bit of the log of container's main processes
+  #A (not counting shell process above running php and behat)
+  #A NOTE: errors during docker setup of travis build won't show up here (can't output all as it is too much in debug/verbose mode)
   - docker-compose --env-file=.env logs -t --tail=15
-  # Will show us what is up, and how long it's been up
+  #A Will show us what is up, and how long it's been up
   - docker ps -s
 after_script:
   - if [ "${BEHAT_OPTS}" != "" ] ; then bin/ezreport ; fi


### PR DESCRIPTION
This PR updates the dist used by Travis to Focal. 

It's related to https://github.com/ezsystems/docker-php/pull/61 - Trusty has OpenSSL 1.0.2, which means that it produces errors when accessing sites using Let's Encrypt certificates. Focal uses the bug-free version (1.1.1).

Focal also has a higher Docker Compose version (1.29.2), which had a change in behaviour compared to the one used on Trusty:
```
Compose supports declaring default environment variables in an environment file named .env placed in the project directory. Docker Compose versions earlier than 1.28, load the .env file from the current working directory, where the command is executed, or from the project directory if this is explicitly set with the --project-directory option. This inconsistency has been addressed starting with +v1.28 by limiting the default .env file path to the project directory. You can use the --env-file commandline option to override the default .env and specify the path to a custom environment file.

The project directory is specified by the order of precedence:

    --project-directory flag
    Folder of the first --file flag
    Current directory
```
[ref](https://docs.docker.com/compose/env-file/)

I'm adding `--env-file=.env` to every docker-compose call to account for that.