### PR TITLE
IBX-2814: Returned null instead of empty array when there are no child nodes

### DIFF
--- a/src/lib/eZ/RichText/Converter/Render.php
+++ b/src/lib/eZ/RichText/Converter/Render.php
@@ -55,11 +55,15 @@ abstract class Render
      *
      * @param \DOMNode $configHash
      *
-     * @return array
+     * @return array|null
      */
     protected function extractHash(DOMNode $configHash)
     {
         $hash = [];
+
+        if ($configHash->childNodes->count() === 0) {
+            return null;
+        }
 
         foreach ($configHash->childNodes as $node) {
             /** @var \DOMText|\DOMElement $node */

--- a/tests/lib/eZ/RichText/Converter/Render/EmbedTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/EmbedTest.php
@@ -741,6 +741,56 @@ class EmbedTest extends TestCase
                     ['601', '602'],
                 ],
             ],
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+  <paragraph>Here is paragraph with embed with empty config value
+    <ezembed xlink:href="ezlocation://601">
+      <ezconfig>
+        <ezvalue key="non-empty">value1</ezvalue>
+        <ezvalue key="empty"/>
+      </ezconfig>
+    </ezembed>
+  </paragraph>
+</section>',
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+  <paragraph>Here is paragraph with embed with empty config value
+    <ezembed xlink:href="ezlocation://601">
+      <ezconfig>
+        <ezvalue key="non-empty">value1</ezvalue>
+        <ezvalue key="empty"/>
+      </ezconfig>
+      <ezpayload><![CDATA[601]]></ezpayload>
+    </ezembed>
+  </paragraph>
+</section>',
+                [],
+                [
+                    [],
+                    [],
+                ],
+                [
+                    [
+                        [
+                            'id' => '601',
+                            'viewType' => 'embed',
+                            [
+                                'embedParams' => [
+                                    'id' => '601',
+                                    'viewType' => 'embed',
+                                    'config' => [
+                                        'non-empty' => 'value1',
+                                        'empty' => null,
+                                    ],
+                                ],
+                            ],
+                            'is_inline' => false,
+                        ],
+                    ],
+                    ['601'],
+                ],
+            ],
         ];
     }
 

--- a/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
+++ b/tests/lib/eZ/RichText/Converter/Render/TemplateTest.php
@@ -289,6 +289,7 @@ class TemplateTest extends TestCase
                     'content' => '<para>Param: value</para>',
                     'params' => [
                         'param' => 'value',
+                        'empty' => null,
                     ],
                     'align' => 'right',
                 ],

--- a/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/input/05-block-content-config.xml
+++ b/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/input/05-block-content-config.xml
@@ -4,6 +4,7 @@
     <ezcontent><para>Param: value</para></ezcontent>
     <ezconfig>
         <ezvalue key="param">value</ezvalue>
+        <ezvalue key="empty"/>
     </ezconfig>
   </eztemplate>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/output/05-block-content-config.xml
+++ b/tests/lib/eZ/RichText/Converter/Render/_fixtures/template/output/05-block-content-config.xml
@@ -6,6 +6,7 @@
     </ezcontent>
     <ezconfig>
       <ezvalue key="param">value</ezvalue>
+      <ezvalue key="empty"/>
     </ezconfig>
     <ezpayload>custom_tag</ezpayload>
   </eztemplate>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | https://issues.ibexa.co/browse/IBX-2814
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | latest stable for bug fixes, master for new features
| **BC breaks**      | **yes**
| **Tests pass**     | yes
| **Doc needed**     | yes (this should probably be mentioned somewhere)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
