### PR TITLE
IBX-5961: Fixed validation error due to not accepted TextAlign value

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -99,7 +99,7 @@
       </xsl:if>
       <xsl:if test="contains( @style, 'text-align:' )">
         <xsl:variable name="textAlign">
-          <xsl:call-template name="extractStyleValue">
+          <xsl:call-template name="extractTextAlignValue">
             <xsl:with-param name="style" select="@style"/>
             <xsl:with-param name="property" select="'text-align'"/>
           </xsl:call-template>
@@ -314,7 +314,7 @@
       </xsl:if>
       <xsl:if test="contains( @style, 'text-align:' )">
         <xsl:variable name="textAlign">
-          <xsl:call-template name="extractStyleValue">
+          <xsl:call-template name="extractTextAlignValue">
             <xsl:with-param name="style" select="@style"/>
             <xsl:with-param name="property" select="'text-align'"/>
           </xsl:call-template>
@@ -728,7 +728,7 @@
       </xsl:if>
       <xsl:if test="contains( @style, 'text-align:' )">
         <xsl:variable name="textAlign">
-          <xsl:call-template name="extractStyleValue">
+          <xsl:call-template name="extractTextAlignValue">
             <xsl:with-param name="style" select="@style"/>
             <xsl:with-param name="property" select="'text-align'"/>
           </xsl:call-template>
@@ -785,6 +785,24 @@
     <xsl:param name="style"/>
     <xsl:param name="property"/>
     <xsl:value-of select="translate( substring-before( substring-after( concat( substring-after( $style, $property ), ';' ), ':' ), ';' ), ' ', '' )"/>
+  </xsl:template>
+
+  <xsl:template name="extractTextAlignValue">
+    <xsl:param name="style"/>
+    <xsl:param name="property"/>
+    <xsl:variable name="alignValue">
+      <xsl:call-template name="extractStyleValue">
+        <xsl:with-param name="style" select="$style"/>
+        <xsl:with-param name="property" select="$property"/>
+      </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:choose>
+      <xsl:when test="$alignValue = 'left' or $alignValue = 'center' or $alignValue = 'right' or $alignValue = 'justify'">
+        <xsl:value-of select="$alignValue"/>
+      </xsl:when>
+      <xsl:otherwise>left</xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template name="normalizeWidth">

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/009-ezxhtmlTextalignInvalid.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/009-ezxhtmlTextalignInvalid.docbook.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
+    <para ezxhtml:textalign="left">Some text</para>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/009-ezxhtmlTextalignInvalid.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/009-ezxhtmlTextalignInvalid.xhtml5.edit.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+    <p style="text-align:start;">Some text</p>
+</section>


### PR DESCRIPTION


| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5961](https://jira.ez.no/browse/IBX-5961)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | Ibexa DXP 3.3 and 4.5
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When cut&pasting from word, you might get TextAlign values that doesn't match our [schema](https://github.com/ezsystems/ezplatform-richtext/blob/v2.3.19/src/lib/eZ/RichText/Resources/schemas/docbook/ezpublish.rng#L777-L780).

With this patch, TextAlign will default to"left" if the value specified is not acceptable

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
