### PR TITLE
[PHPStan] Added new issues to PHPStan baseline after the release

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -971,6 +971,11 @@ parameters:
 			path: src/lib/eZ/RichText/Converter/Render/Template.php
 
 		-
+			message: "#^Parameter \\#3 \\$template of method EzSystems\\\\EzPlatformRichText\\\\eZ\\\\RichText\\\\Converter\\\\Render\\\\Template\\:\\:processTemplate\\(\\) expects DOMElement, DOMNode given\\.$#"
+			count: 1
+			path: src/lib/eZ/RichText/Converter/Render/Template.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between DOMNode and false will always evaluate to false\\.$#"
 			count: 1
 			path: src/lib/eZ/RichText/Converter/Render/Template.php
@@ -1131,6 +1136,11 @@ parameters:
 			path: src/lib/eZ/RichText/Validator/CustomTagsValidator.php
 
 		-
+			message: "#^Call to an undefined method DOMNode\\:\\:getAttribute\\(\\)\\.$#"
+			count: 2
+			path: src/lib/eZ/RichText/Validator/CustomTagsValidator.php
+
+		-
 			message: "#^Method EzSystems\\\\EzPlatformRichText\\\\eZ\\\\RichText\\\\Validator\\\\CustomTagsValidator\\:\\:__construct\\(\\) has parameter \\$customTagsConfiguration with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/eZ/RichText/Validator/CustomTagsValidator.php
@@ -1167,6 +1177,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$document of class DOMXPath constructor expects DOMDocument, DOMDocument\\|false given\\.$#"
+			count: 1
+			path: src/lib/eZ/RichText/Validator/Validator.php
+
+		-
+			message: "#^Parameter \\#1 \\$failedAssert of method EzSystems\\\\EzPlatformRichText\\\\eZ\\\\RichText\\\\Validator\\\\Validator\\:\\:formatSVRLFailure\\(\\) expects DOMElement, DOMNode given\\.$#"
 			count: 1
 			path: src/lib/eZ/RichText/Validator/Validator.php
 


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | n/a |
| **Type**                                   | bug |
| **Target Ibexa version** | `v3.3`+ |
| **BC breaks**                          | no |

PHPStan v1.10.22 released 3 days ago uncovered new pre-existing issues related to DOM extension. The proper solution is not feasible ATM as it comes directly from the extension.
The issue is that `\DOMXPath::query` declares that it returns `DOMNodeList` which contains `DOMNode` instances, but it actually returns a list which contains `DOMElement` instances. It requires further investigation if it's a bug in DOM or if there's a case when it returns actually DOMNode and shouldn't be passed to the method.

The issues reported:

```
------ ----------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/lib/eZ/RichText/Converter/Render/Template.php                                                                                                          
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------- 
  71     Parameter #3 $template of method EzSystems\EzPlatformRichText\eZ\RichText\Converter\Render\Template::processTemplate() expects DOMElement, DOMNode given.  
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------- 
  Line   src/lib/eZ/RichText/Validator/CustomTagsValidator.php  
 ------ ------------------------------------------------------- 
  53     Call to an undefined method DOMNode::getAttribute().   
  74     Call to an undefined method DOMNode::getAttribute().   
 ------ ------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/lib/eZ/RichText/Validator/Validator.php                                                                                                                
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------- 
  136    Parameter #1 $failedAssert of method EzSystems\EzPlatformRichText\eZ\RichText\Validator\Validator::formatSVRLFailure() expects DOMElement, DOMNode given.  
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------- 
```


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review.