### PR TITLE
IBX-6485:  Forced `RichText\Renderer`to utilize `PermissionResolver` instead of `AuthorizationChecker`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -201,11 +201,6 @@ parameters:
 			path: src/bundle/eZ/RichText/Renderer.php
 
 		-
-			message: "#^Method EzSystems\\\\EzPlatformRichTextBundle\\\\eZ\\\\RichText\\\\Renderer\\:\\:checkContentPermissions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/eZ/RichText/Renderer.php
-
-		-
 			message: "#^Method EzSystems\\\\EzPlatformRichTextBundle\\\\eZ\\\\RichText\\\\Renderer\\:\\:getEmbedTemplateName\\(\\) has parameter \\$isDenied with no type specified\\.$#"
 			count: 1
 			path: src/bundle/eZ/RichText/Renderer.php
@@ -1627,36 +1622,6 @@ parameters:
 
 		-
 			message: "#^Method EzSystems\\\\Tests\\\\EzPlatformRichTextBundle\\\\eZ\\\\RichText\\\\RendererTest\\:\\:testRenderTagWithTemplate\\(\\) has parameter \\$templateEngineTemplate with no type specified\\.$#"
-			count: 1
-			path: tests/bundle/eZ/RichText/RendererTest.php
-
-		-
-			message: "#^Property EzSystems\\\\Tests\\\\EzPlatformRichTextBundle\\\\eZ\\\\RichText\\\\RendererTest\\:\\:\\$authorizationCheckerMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Symfony\\\\Component\\\\Security\\\\Core\\\\Authorization\\\\AuthorizationCheckerInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/bundle/eZ/RichText/RendererTest.php
-
-		-
-			message: "#^Property EzSystems\\\\Tests\\\\EzPlatformRichTextBundle\\\\eZ\\\\RichText\\\\RendererTest\\:\\:\\$configResolverMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Psr\\\\Log\\\\LoggerInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/bundle/eZ/RichText/RendererTest.php
-
-		-
-			message: "#^Property EzSystems\\\\Tests\\\\EzPlatformRichTextBundle\\\\eZ\\\\RichText\\\\RendererTest\\:\\:\\$loaderMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Twig\\\\Loader\\\\LoaderInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/bundle/eZ/RichText/RendererTest.php
-
-		-
-			message: "#^Property EzSystems\\\\Tests\\\\EzPlatformRichTextBundle\\\\eZ\\\\RichText\\\\RendererTest\\:\\:\\$loggerMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Psr\\\\Log\\\\LoggerInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/bundle/eZ/RichText/RendererTest.php
-
-		-
-			message: "#^Property EzSystems\\\\Tests\\\\EzPlatformRichTextBundle\\\\eZ\\\\RichText\\\\RendererTest\\:\\:\\$repositoryMock \\(eZ\\\\Publish\\\\API\\\\Repository\\\\Repository&PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
-			count: 1
-			path: tests/bundle/eZ/RichText/RendererTest.php
-
-		-
-			message: "#^Property EzSystems\\\\Tests\\\\EzPlatformRichTextBundle\\\\eZ\\\\RichText\\\\RendererTest\\:\\:\\$templateEngineMock \\(PHPUnit\\\\Framework\\\\MockObject\\\\MockObject&Symfony\\\\Component\\\\Templating\\\\EngineInterface\\) does not accept PHPUnit\\\\Framework\\\\MockObject\\\\MockObject\\.$#"
 			count: 1
 			path: tests/bundle/eZ/RichText/RendererTest.php
 

--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -33,16 +33,16 @@ services:
     ezrichtext.renderer:
         class: EzSystems\EzPlatformRichTextBundle\eZ\RichText\Renderer
         arguments:
-            - '@ezpublish.api.repository'
-            - '@security.authorization_checker'
-            - '@ezpublish.config.resolver'
-            - '@twig'
-            - '%ezrichtext.tag.namespace%'
-            - '%ezrichtext.style.namespace%'
-            - '%ezrichtext.embed.namespace%'
-            - '@?logger'
-            - '%ezplatform.ezrichtext.custom_tags%'
-            - '%ezplatform.ezrichtext.custom_styles%'
+            $repository: '@ezpublish.api.repository'
+            $configResolver: '@ezpublish.config.resolver'
+            $templateEngine: '@twig'
+            $permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
+            $tagConfigurationNamespace: '%ezrichtext.tag.namespace%%'
+            $styleConfigurationNamespace: '%ezrichtext.style.namespace%'
+            $embedConfigurationNamespace: '%ezrichtext.embed.namespace%'
+            $logger: '@?logger'
+            $customTagsConfiguration: '%ezplatform.ezrichtext.custom_tags%'
+            $customStylesConfiguration: '%ezplatform.ezrichtext.custom_styles%'
 
     ezrichtext.converter.link:
         class: EzSystems\EzPlatformRichText\eZ\RichText\Converter\Link

--- a/src/bundle/Resources/config/fieldtype_services.yaml
+++ b/src/bundle/Resources/config/fieldtype_services.yaml
@@ -37,7 +37,7 @@ services:
             $configResolver: '@ezpublish.config.resolver'
             $templateEngine: '@twig'
             $permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
-            $tagConfigurationNamespace: '%ezrichtext.tag.namespace%%'
+            $tagConfigurationNamespace: '%ezrichtext.tag.namespace%'
             $styleConfigurationNamespace: '%ezrichtext.style.namespace%'
             $embedConfigurationNamespace: '%ezrichtext.embed.namespace%'
             $logger: '@?logger'

--- a/tests/bundle/eZ/RichText/RendererTest.php
+++ b/tests/bundle/eZ/RichText/RendererTest.php
@@ -8,7 +8,8 @@ declare(strict_types=1);
 
 namespace EzSystems\Tests\EzPlatformRichTextBundle\eZ\RichText;
 
-use eZ\Publish\Core\Repository\Repository;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -18,22 +19,39 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
 use Twig\Loader\LoaderInterface;
 
-class RendererTest extends TestCase
+final class RendererTest extends TestCase
 {
+    /** @var \PHPUnit\Framework\MockObject\MockObject&\eZ\Publish\API\Repository\Repository */
+    private $repositoryMock;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $configResolverMock;
+
+    /** @var \Twig\Environment&\PHPUnit\Framework\MockObject\MockObject */
+    private $templateEngineMock;
+
+    /** @var \eZ\Publish\API\Repository\PermissionResolver&\PHPUnit\Framework\MockObject\MockObject */
+    private $permissionResolverMock;
+
+    /** @var \Psr\Log\LoggerInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $loggerMock;
+
+    /** @var \Twig\Loader\LoaderInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $loaderMock;
+
     public function setUp(): void
     {
-        $this->repositoryMock = $this->getRepositoryMock();
-        $this->authorizationCheckerMock = $this->getAuthorizationCheckerMock();
-        $this->configResolverMock = $this->getConfigResolverMock();
-        $this->templateEngineMock = $this->getTemplateEngineMock();
-        $this->loggerMock = $this->getLoggerMock();
-        $this->loaderMock = $this->getLoaderMock();
+        $this->repositoryMock = $this->createMock(Repository::class);
+        $this->configResolverMock = $this->createMock(ConfigResolverInterface::class);
+        $this->templateEngineMock = $this->createMock(Environment::class);
+        $this->permissionResolverMock = $this->createMock(PermissionResolver::class);
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+        $this->loaderMock = $this->createMock(LoaderInterface::class);
         parent::setUp();
     }
 
@@ -406,8 +424,7 @@ class RendererTest extends TestCase
         $renderer
             ->expects($this->once())
             ->method('checkContentPermissions')
-            ->with($contentMock)
-            ->willReturn($contentMock);
+            ->with($contentMock);
 
         $renderer
             ->expects($this->once())
@@ -462,8 +479,7 @@ class RendererTest extends TestCase
         $renderer
             ->expects($this->once())
             ->method('checkContentPermissions')
-            ->with($contentMock)
-            ->willReturn($contentMock);
+            ->with($contentMock);
 
         $renderer
             ->expects($this->never())
@@ -987,8 +1003,7 @@ class RendererTest extends TestCase
             $renderer
                 ->expects($this->once())
                 ->method('checkContentPermissions')
-                ->with($contentMock)
-                ->willReturn($contentMock);
+                ->with($contentMock);
         }
 
         if (!isset($renderTemplate)) {
@@ -1707,9 +1722,9 @@ class RendererTest extends TestCase
             ->setConstructorArgs(
                 [
                     $this->repositoryMock,
-                    $this->authorizationCheckerMock,
                     $this->configResolverMock,
                     $this->templateEngineMock,
+                    $this->permissionResolverMock,
                     'test.name.space.tag',
                     'test.name.space.style',
                     'test.name.space.embed',
@@ -1718,84 +1733,6 @@ class RendererTest extends TestCase
             )
             ->setMethods($methods)
             ->getMock();
-    }
-
-    /**
-     * @var \eZ\Publish\API\Repository\Repository|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $repositoryMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getRepositoryMock()
-    {
-        return $this->createMock(Repository::class);
-    }
-
-    /**
-     * @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $authorizationCheckerMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getAuthorizationCheckerMock()
-    {
-        return $this->createMock(AuthorizationCheckerInterface::class);
-    }
-
-    /**
-     * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $configResolverMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getConfigResolverMock()
-    {
-        return $this->createMock(ConfigResolverInterface::class);
-    }
-
-    /**
-     * @var \Symfony\Component\Templating\EngineInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $templateEngineMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getTemplateEngineMock()
-    {
-        return $this->createMock(Environment::class);
-    }
-
-    /**
-     * @var \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $loggerMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getLoggerMock()
-    {
-        return $this->createMock(LoggerInterface::class);
-    }
-
-    /**
-     * @var \Twig\Loader\LoaderInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    protected $loaderMock;
-
-    /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getLoaderMock()
-    {
-        return $this->createMock(LoaderInterface::class);
     }
 
     protected function getContentMock($mainLocationId)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-6485](https://issues.ibexa.co/browse/IBX-6485)
| **Improvement**| yes
| **New feature**    | no
| **Target version** | `v3.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Backport of https://github.com/ibexa/fieldtype-richtext/pull/118

Failing test should be fixed after https://github.com/ezsystems/ezplatform-richtext/pull/240.

**TODO**:
- [x] Implement feature.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
