### PR TITLE
IBX-7579:Richtext: Rows are added to ezurl_object_link on every save

### DIFF
--- a/src/lib/eZ/FieldType/RichText/RichTextStorage.php
+++ b/src/lib/eZ/FieldType/RichText/RichTextStorage.php
@@ -83,7 +83,10 @@ class RichTextStorage extends GatewayBasedStorage
 
         $urlIdMap = $this->gateway->getUrlIdMap(array_keys($urlSet));
         $contentIds = $this->gateway->getContentIds(array_keys($remoteIdSet));
-        $urlLinkSet = [];
+        $urlLinkSet = $this->gateway->getUrlsFromUrlLink(
+            $field->id,
+            $versionInfo->versionNo
+        );
 
         foreach ($links as $index => $link) {
             list(, $scheme, $url, $fragment) = $linksInfo[$index];

--- a/src/lib/eZ/FieldType/RichText/RichTextStorage/Gateway.php
+++ b/src/lib/eZ/FieldType/RichText/RichTextStorage/Gateway.php
@@ -79,6 +79,16 @@ abstract class Gateway extends StorageGateway
     }
 
     /**
+     * Return a list of URLs used by the given field and version.
+     *
+     * @return bool[] An array of URLs, with urls as keys
+     */
+    public function getUrlsFromUrlLink(int $fieldId, int $versionNo): array
+    {
+        return $this->urlGateway->getUrlsFromUrlLink($fieldId, $versionNo);
+    }
+
+    /**
      * Creates link to URL with $urlId for field with $fieldId in $versionNo.
      *
      * @param int|string $urlId

--- a/src/lib/eZ/FieldType/RichText/RichTextStorage/Gateway.php
+++ b/src/lib/eZ/FieldType/RichText/RichTextStorage/Gateway.php
@@ -81,11 +81,17 @@ abstract class Gateway extends StorageGateway
     /**
      * Return a list of URLs used by the given field and version.
      *
-     * @return bool[] An array of URLs, with urls as keys
+     * array<string, boolean> An array of URLs, with urls as keys
      */
     public function getUrlsFromUrlLink(int $fieldId, int $versionNo): array
     {
-        return $this->urlGateway->getUrlsFromUrlLink($fieldId, $versionNo);
+        $rows = $this->urlGateway->getUrlsFromUrlLink($fieldId, $versionNo);
+        $result = [];
+        foreach ($rows as $url) {
+            $result[$url] = true;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/lib/eZ/FieldType/RichText/RichTextStorageTest.php
+++ b/tests/lib/eZ/FieldType/RichText/RichTextStorageTest.php
@@ -325,6 +325,13 @@ class RichTextStorageTest extends TestCase
             ->method('getContentIds')
             ->with($this->equalTo($remoteIds))
             ->willReturn($contentIds);
+
+        $gateway
+            ->expects($this->once())
+            ->method('getUrlsFromUrlLink')
+            ->with($this->equalTo(42), $this->equalTo(1))
+            ->willReturn([]);
+
         $gateway->expects($this->never())->method('getIdUrlMap');
         if (empty($insertLinks)) {
             $gateway->expects($this->never())->method('insertUrl');
@@ -338,9 +345,12 @@ class RichTextStorageTest extends TestCase
                 ->willReturn($linkMap['id']);
         }
 
-        $versionInfo = new VersionInfo();
+        $versionInfo = new VersionInfo(['versionNo' => 1]);
         $value = new FieldValue(['data' => $xmlString]);
-        $field = new Field(['value' => $value]);
+        $field = new Field([
+            'value' => $value,
+            'id' => 42,
+        ]);
 
         $storage = $this->getPartlyMockedStorage($gateway);
         $storage->storeFieldData(


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-7579](https://jira.ez.no/browse/IBX-7579)
| **Bug**| yes
| **New feature**    | no
| **Target version** | 2.3
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | maybe

If the same link is referenced to several times in the same richtext field, there is a mechanism for preventing it from being added to the `ezurl_object_link`  table multiple times. However, it doesn't take into account that draft can be saved multiple times.

Corresponding kernel PR : https://github.com/ezsystems/ezplatform-kernel/pull/402

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
