### PR TITLE
IBX-8258: richtext: Html5Input is not washed for duplicate IDs

### DIFF
--- a/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/src/lib/eZ/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -9,6 +9,9 @@
     version="1.0">
   <xsl:output indent="yes" encoding="UTF-8"/>
 
+  <xsl:key name="ids" match="*[@id]" use="@id"/>
+  <xsl:key name="ids" match="ezxhtml5:a[@name]" use="@name"/>
+
   <xsl:template match="/ezxhtml5:section">
     <section xmlns="http://docbook.org/ns/docbook"
              xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -85,13 +88,30 @@
     </xsl:choose>
   </xsl:template>
 
+  <xsl:template name="addUniqueIdAttribute">
+    <xsl:param name="attribute"/>
+
+    <xsl:if test="$attribute">
+      <xsl:choose>
+        <xsl:when test="count(key('ids', $attribute)) &gt; 1">
+          <xsl:attribute name="xml:id">
+            <xsl:value-of select="concat($attribute, '_', generate-id(.))"/>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:attribute name="xml:id">
+            <xsl:value-of select="$attribute"/>
+          </xsl:attribute>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="ezxhtml5:p" name="paragraph">
     <para>
-      <xsl:if test="@id">
-        <xsl:attribute name="xml:id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
-      </xsl:if>
+      <xsl:call-template name="addUniqueIdAttribute">
+        <xsl:with-param name="attribute" select="@id"/>
+      </xsl:call-template>
       <xsl:if test="@class">
         <xsl:attribute name="ezxhtml:class">
           <xsl:value-of select="@class"/>
@@ -125,11 +145,9 @@
 
   <xsl:template match="ezxhtml5:pre">
     <xsl:element name="programlisting">
-      <xsl:if test="@id">
-        <xsl:attribute name="xml:id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
-      </xsl:if>
+      <xsl:call-template name="addUniqueIdAttribute">
+        <xsl:with-param name="attribute" select="@id"/>
+      </xsl:call-template>
       <xsl:if test="@class">
         <xsl:attribute name="ezxhtml:class">
           <xsl:value-of select="@class"/>
@@ -243,11 +261,9 @@
           </xsl:otherwise>
         </xsl:choose>
       </xsl:attribute>
-      <xsl:if test="@id">
-        <xsl:attribute name="xml:id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
-      </xsl:if>
+      <xsl:call-template name="addUniqueIdAttribute">
+        <xsl:with-param name="attribute" select="@id"/>
+      </xsl:call-template>
       <xsl:if test="@title">
         <xsl:attribute name="xlink:title">
           <xsl:value-of select="@title"/>
@@ -268,13 +284,13 @@
   <xsl:template name="link.anchor">
     <xsl:param name="attribute"/>
     <anchor>
-      <xsl:attribute name="xml:id">
-        <xsl:value-of select="$attribute"/>
-      </xsl:attribute>
+      <xsl:call-template name="addUniqueIdAttribute">
+        <xsl:with-param name="attribute" select="$attribute"/>
+      </xsl:call-template>
     </anchor>
   </xsl:template>
 
-  <xsl:template match="ezxhtml5:a[not(@name=preceding::ezxhtml5:a/@name)]">
+  <xsl:template match="ezxhtml5:a">
     <xsl:choose>
       <xsl:when test="@href">
         <xsl:call-template name="link.href"/>
@@ -307,11 +323,9 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="@id">
-        <xsl:attribute name="xml:id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
-      </xsl:if>
+      <xsl:call-template name="addUniqueIdAttribute">
+        <xsl:with-param name="attribute" select="@id"/>
+      </xsl:call-template>
       <xsl:if test="contains( @style, 'text-align:' )">
         <xsl:variable name="textAlign">
           <xsl:call-template name="extractTextAlignValue">
@@ -334,11 +348,9 @@
 
   <xsl:template match="ezxhtml5:ol">
     <orderedlist>
-      <xsl:if test="@id">
-        <xsl:attribute name="xml:id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
-      </xsl:if>
+      <xsl:call-template name="addUniqueIdAttribute">
+        <xsl:with-param name="attribute" select="@id"/>
+      </xsl:call-template>
       <xsl:if test="@class">
         <xsl:attribute name="ezxhtml:class">
           <xsl:value-of select="@class"/>
@@ -351,11 +363,9 @@
 
   <xsl:template match="ezxhtml5:ul">
     <itemizedlist>
-      <xsl:if test="@id">
-        <xsl:attribute name="xml:id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
-      </xsl:if>
+      <xsl:call-template name="addUniqueIdAttribute">
+        <xsl:with-param name="attribute" select="@id"/>
+      </xsl:call-template>
       <xsl:if test="@class">
         <xsl:attribute name="ezxhtml:class">
           <xsl:value-of select="@class"/>
@@ -397,11 +407,9 @@
       </xsl:choose>
     </xsl:variable>
     <xsl:element name="{$tablename}" namespace="http://docbook.org/ns/docbook">
-      <xsl:if test="@id">
-        <xsl:attribute name="xml:id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
-      </xsl:if>
+      <xsl:call-template name="addUniqueIdAttribute">
+        <xsl:with-param name="attribute" select="@id"/>
+      </xsl:call-template>
       <xsl:if test="@class">
         <xsl:attribute name="class">
           <xsl:value-of select="@class"/>
@@ -625,11 +633,9 @@
   </xsl:template>
 
   <xsl:template name="addCommonEmbedAttributes">
-    <xsl:if test="@id">
-      <xsl:attribute name="xml:id">
-        <xsl:value-of select="@id"/>
-      </xsl:attribute>
-    </xsl:if>
+    <xsl:call-template name="addUniqueIdAttribute">
+      <xsl:with-param name="attribute" select="@id"/>
+    </xsl:call-template>
     <xsl:if test="@data-href">
       <xsl:attribute name="xlink:href">
         <xsl:value-of select="@data-href"/>
@@ -672,11 +678,9 @@
           <xsl:value-of select="@title"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="@id">
-        <xsl:attribute name="xml:id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
-      </xsl:if>
+      <xsl:call-template name="addUniqueIdAttribute">
+        <xsl:with-param name="attribute" select="@id"/>
+      </xsl:call-template>
       <xsl:if test="@class">
         <xsl:attribute name="ezxhtml:class">
           <xsl:value-of select="@class"/>
@@ -721,10 +725,10 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:if test="@id">
-        <xsl:attribute name="xml:id">
-          <xsl:value-of select="@id"/>
-        </xsl:attribute>
+      <xsl:if test="@data-ezelement='eztemplate'">
+        <xsl:call-template name="addUniqueIdAttribute">
+          <xsl:with-param name="attribute" select="@id"/>
+        </xsl:call-template>
       </xsl:if>
       <xsl:if test="contains( @style, 'text-align:' )">
         <xsl:variable name="textAlign">

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.docbook.xml
@@ -6,6 +6,6 @@
         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
         version="5.0-variant ezpublish-1.0">
     <para><anchor xml:id="top"/>some anchor with a name attribute.</para>
-    <para><anchor xml:id="bottom"/>some anchor with a name attribute.</para>
-    <para>another anchor that should be removed due to lack of name uniqueness.</para>
+    <para><anchor xml:id="bottom_idm5"/>some anchor with a name attribute.</para>
+    <para><anchor xml:id="bottom_idm7"/>another anchor with the same name attribute.</para>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/008-anchor.xhtml5.edit.xml
@@ -2,5 +2,5 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
     <p><a name="top"/>some anchor with a name attribute.</p>
     <p><a name="bottom"/>some anchor with a name attribute.</p>
-    <p><a name="bottom"/>another anchor that should be removed due to lack of name uniqueness.</p>
+    <p><a name="bottom"/>another anchor with the same name attribute.</p>
 </section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/010-duplicatedIds.docbook.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/010-duplicatedIds.docbook.xml
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+    <para xml:id="lipsum_idm2">Lorem ipsum</para>
+    <para xml:id="lipsum_idm3">Nunc in dignissim ex</para>
+    <programlisting xml:id="lipsum_idm4"><![CDATA[Literal with CNAME end sequence here : ]]]]><![CDATA[> and some more text here]]></programlisting>
+    <programlisting xml:id="programlisting"><![CDATA[Literal with CNAME end sequence here : ]]]]><![CDATA[> and some more text here]]></programlisting>
+    <programlisting xml:id="programlistingdup_idm6"><![CDATA[Literal with CNAME end sequence here : ]]]]><![CDATA[> and some more text here]]></programlisting>
+    <programlisting xml:id="programlistingdup_idm7"><![CDATA[Literal with CNAME end sequence here : ]]]]><![CDATA[> and some more text here]]></programlisting>
+    <para>The anchor element<anchor xml:id="lipsum_idm9"/> is empty and contributes nothing to the flow of the content in which it occurs. It is only useful as a target.</para>
+    <para>The anchor element<anchor xml:id="anchor"/> is empty and contributes nothing to the flow of the content in which it occurs. It is only useful as a target.</para>
+    <para>The anchor element<anchor xml:id="anchordup_idm13"/> is empty and contributes nothing to the flow of the content in which it occurs. It is only useful as a target.</para>
+    <para>The anchor element<anchor xml:id="anchordup_idm15"/> is empty and contributes nothing to the flow of the content in which it occurs. It is only useful as a target.</para>
+    <para><link ezxhtml:class="linkClass1" xlink:href="#anchor" xlink:show="new" xlink:title="Anchor link title" xml:id="lipsum_idm17">Jump to content</link></para>
+    <para><link ezxhtml:class="linkClass1" xlink:href="#anchor" xlink:show="new" xlink:title="Anchor link title" xml:id="link">Jump to content</link></para>
+    <para><link ezxhtml:class="linkClass1" xlink:href="#anchor" xlink:show="new" xlink:title="Anchor link title" xml:id="linkdup_idm21">Jump to content</link></para>
+    <para><link ezxhtml:class="linkClass1" xlink:href="#anchor" xlink:show="new" xlink:title="Anchor link title" xml:id="linkdup_idm23">Jump to content</link></para>
+    <title ezxhtml:class="titleClass" ezxhtml:level="1" xml:id="lipsum_idm24">This is a heading.</title>
+    <title ezxhtml:class="titleClass" ezxhtml:level="1" xml:id="title">This is a heading.</title>
+    <title ezxhtml:class="titleClass" ezxhtml:level="1" xml:id="titledup_idm26">This is a heading.</title>
+    <title ezxhtml:class="titleClass" ezxhtml:level="1" xml:id="titledup_idm27">This is a heading.</title>
+    <orderedlist xml:id="lipsum_idm28" ezxhtml:class="orderedListClass">
+        <ezattribute>
+            <ezvalue key="name-1">value 1</ezvalue>
+            <ezvalue key="name-2">value 2</ezvalue>
+            <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-2">value 2</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-2">value 2</ezvalue>
+                </ezattribute>This is a list item.</para>
+        </listitem>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-3">value 3</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-3">value 3</ezvalue>
+                </ezattribute>This is a list item 2.</para>
+        </listitem>
+    </orderedlist>
+    <orderedlist xml:id="orderedlist" ezxhtml:class="orderedListClass">
+        <ezattribute>
+            <ezvalue key="name-1">value 1</ezvalue>
+            <ezvalue key="name-2">value 2</ezvalue>
+            <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-2">value 2</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-2">value 2</ezvalue>
+                </ezattribute>This is a list item.</para>
+        </listitem>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-3">value 3</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-3">value 3</ezvalue>
+                </ezattribute>This is a list item 2.</para>
+        </listitem>
+    </orderedlist>
+    <orderedlist xml:id="orderedlistdup_idm34" ezxhtml:class="orderedListClass">
+        <ezattribute>
+            <ezvalue key="name-1">value 1</ezvalue>
+            <ezvalue key="name-2">value 2</ezvalue>
+            <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-2">value 2</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-2">value 2</ezvalue>
+                </ezattribute>This is a list item.</para>
+        </listitem>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-3">value 3</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-3">value 3</ezvalue>
+                </ezattribute>This is a list item 2.</para>
+        </listitem>
+    </orderedlist>
+    <orderedlist xml:id="orderedlistdup_idm37" ezxhtml:class="orderedListClass">
+        <ezattribute>
+            <ezvalue key="name-1">value 1</ezvalue>
+            <ezvalue key="name-2">value 2</ezvalue>
+            <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-2">value 2</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-2">value 2</ezvalue>
+                </ezattribute>This is a list item.</para>
+        </listitem>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-3">value 3</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-3">value 3</ezvalue>
+                </ezattribute>This is a list item 2.</para>
+        </listitem>
+    </orderedlist>
+    <itemizedlist xml:id="lipsum_idm40" >
+        <ezattribute>
+            <ezvalue key="name-1">value 1</ezvalue>
+            <ezvalue key="name-2">value 2</ezvalue>
+            <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-2">value 2</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-2">value 2</ezvalue>
+                </ezattribute>This is a list item.</para>
+        </listitem>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-3">value 3</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-3">value 3</ezvalue>
+                </ezattribute>This is a list item 2.</para>
+        </listitem>
+    </itemizedlist>
+    <itemizedlist xml:id="itemizedList" >
+        <ezattribute>
+            <ezvalue key="name-1">value 1</ezvalue>
+            <ezvalue key="name-2">value 2</ezvalue>
+            <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-2">value 2</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-2">value 2</ezvalue>
+                </ezattribute>This is a list item.</para>
+        </listitem>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-3">value 3</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-3">value 3</ezvalue>
+                </ezattribute>This is a list item 2.</para>
+        </listitem>
+    </itemizedlist>
+    <itemizedlist xml:id="itemizedListdup_idm46" >
+        <ezattribute>
+            <ezvalue key="name-1">value 1</ezvalue>
+            <ezvalue key="name-2">value 2</ezvalue>
+            <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-2">value 2</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-2">value 2</ezvalue>
+                </ezattribute>This is a list item.</para>
+        </listitem>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-3">value 3</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-3">value 3</ezvalue>
+                </ezattribute>This is a list item 2.</para>
+        </listitem>
+    </itemizedlist>
+    <itemizedlist xml:id="itemizedListdup_idm49" >
+        <ezattribute>
+            <ezvalue key="name-1">value 1</ezvalue>
+            <ezvalue key="name-2">value 2</ezvalue>
+            <ezvalue key="name-3">value 3</ezvalue>
+        </ezattribute>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-2">value 2</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-2">value 2</ezvalue>
+                </ezattribute>This is a list item.</para>
+        </listitem>
+        <listitem ezxhtml:class="listItemClass">
+            <ezattribute>
+                <ezvalue key="name-3">value 3</ezvalue>
+            </ezattribute>
+            <para ezxhtml:class="listItemClass">
+                <ezattribute>
+                    <ezvalue key="name-3">value 3</ezvalue>
+                </ezattribute>This is a list item 2.</para>
+        </listitem>
+    </itemizedlist>
+    <table class="tableClass" width="24%" title="tableTitle" xml:id="lipsum_idm52">
+        <caption>Table caption.</caption>
+        <tbody>
+            <tr class="rowClass1">
+                <th class="headingClass1" ezxhtml:width="102" valign="top" colspan="1" rowspan="5" abbr="XSLT" scope="col">11</th>
+                <th class="headingClass2" ezxhtml:width="37%" valign="middle" colspan="2" rowspan="6" abbr="XSD" scope="row">12</th>
+            </tr>
+        </tbody>
+    </table>
+    <table class="tableClass" width="24%" title="tableTitle" xml:id="table">
+        <caption>Table caption.</caption>
+        <tbody>
+            <tr class="rowClass1">
+                <th class="headingClass1" ezxhtml:width="102" valign="top" colspan="1" rowspan="5" abbr="XSLT" scope="col">11</th>
+                <th class="headingClass2" ezxhtml:width="37%" valign="middle" colspan="2" rowspan="6" abbr="XSD" scope="row">12</th>
+            </tr>
+        </tbody>
+    </table>
+    <table class="tableClass" width="24%" title="tableTitle" xml:id="tabledup_idm64">
+        <caption>Table caption.</caption>
+        <tbody>
+            <tr class="rowClass1">
+                <th class="headingClass1" ezxhtml:width="102" valign="top" colspan="1" rowspan="5" abbr="XSLT" scope="col">11</th>
+                <th class="headingClass2" ezxhtml:width="37%" valign="middle" colspan="2" rowspan="6" abbr="XSD" scope="row">12</th>
+            </tr>
+        </tbody>
+    </table>
+    <table class="tableClass" width="24%" title="tableTitle" xml:id="tabledup_idm70">
+        <caption>Table caption.</caption>
+        <tbody>
+            <tr class="rowClass1">
+                <th class="headingClass1" ezxhtml:width="102" valign="top" colspan="1" rowspan="5" abbr="XSLT" scope="col">11</th>
+                <th class="headingClass2" ezxhtml:width="37%" valign="middle" colspan="2" rowspan="6" abbr="XSD" scope="row">12</th>
+            </tr>
+        </tbody>
+    </table>
+    <ezembed view="line" ezxhtml:align="right" ezxhtml:class="embedClass2" xlink:href="ezlocation://601" xml:id="lipsum_idm76"/>
+    <ezembed view="line" ezxhtml:align="right" ezxhtml:class="embedClass2" xlink:href="ezlocation://601" xml:id="embed"/>
+    <ezembed view="line" ezxhtml:align="right" ezxhtml:class="embedClass2" xlink:href="ezlocation://601" xml:id="embeddup_idm78"/>
+    <ezembed view="line" ezxhtml:align="right" ezxhtml:class="embedClass2" xlink:href="ezlocation://601" xml:id="embeddup_idm79"/>
+    <para>Some<ezembedinline xlink:href="ezcontent://601" xml:id="lipsum_idm81"><ezattribute><ezvalue key="name-1">value 1</ezvalue><ezvalue key="name-2">value 2</ezvalue></ezattribute></ezembedinline> content.</para>
+    <para>Some<ezembedinline xlink:href="ezcontent://601" xml:id="embedInline"><ezattribute><ezvalue key="name-1">value 1</ezvalue><ezvalue key="name-2">value 2</ezvalue></ezattribute></ezembedinline> content.</para>
+    <para>Some<ezembedinline xlink:href="ezcontent://601" xml:id="embedInlinedup_idm85"><ezattribute><ezvalue key="name-1">value 1</ezvalue><ezvalue key="name-2">value 2</ezvalue></ezattribute></ezembedinline> content.</para>
+    <para>Some<ezembedinline xlink:href="ezcontent://601" xml:id="embedInlinedup_idm87"><ezattribute><ezvalue key="name-1">value 1</ezvalue><ezvalue key="name-2">value 2</ezvalue></ezattribute></ezembedinline> content.</para>
+    <ezembed ezxhtml:align="right" ezxhtml:class="embedClass2" xlink:href="ezlocation://601">
+        <ezlink ezxhtml:class="linkClass2" xlink:href="ezlocation://202" xlink:show="none" xml:id="lipsum_idm89"/>
+    </ezembed>
+    <ezembed ezxhtml:align="right" ezxhtml:class="embedClass2" xlink:href="ezlocation://601">
+        <ezlink ezxhtml:class="linkClass2" xlink:href="ezlocation://202" xlink:show="none" xml:id="ezlink"/>
+    </ezembed>
+    <ezembed ezxhtml:align="right" ezxhtml:class="embedClass2" xlink:href="ezlocation://601">
+        <ezlink ezxhtml:class="linkClass2" xlink:href="ezlocation://202" xlink:show="none" xml:id="ezlinkdup_idm93"/>
+    </ezembed>
+    <ezembed ezxhtml:align="right" ezxhtml:class="embedClass2" xlink:href="ezlocation://601">
+        <ezlink ezxhtml:class="linkClass2" xlink:href="ezlocation://202" xlink:show="none" xml:id="ezlinkdup_idm95"/>
+    </ezembed>
+    <para>Some <ezembedinline view="embed-inline-custom" ezxhtml:align="left" ezxhtml:class="embedClass" xlink:href="ezcontent://601" xml:id="id3_idm97"><ezlink ezxhtml:class="linkClass" xlink:href="ezcontent://106" xlink:show="new" xlink:title="Link title" xml:id="lipsum_idm98"/></ezembedinline></para>
+    <para>Some <ezembedinline view="embed-inline-custom" ezxhtml:align="left" ezxhtml:class="embedClass" xlink:href="ezcontent://601" xml:id="id3_idm100"><ezlink ezxhtml:class="linkClass" xlink:href="ezcontent://106" xlink:show="new" xlink:title="Link title" xml:id="ezlinkembed"/></ezembedinline></para>
+    <para>Some <ezembedinline view="embed-inline-custom" ezxhtml:align="left" ezxhtml:class="embedClass" xlink:href="ezcontent://601" xml:id="id3_idm103"><ezlink ezxhtml:class="linkClass" xlink:href="ezcontent://106" xlink:show="new" xlink:title="Link title" xml:id="ezlinkembeddup_idm104"/></ezembedinline></para>
+    <para>Some <ezembedinline view="embed-inline-custom" ezxhtml:align="left" ezxhtml:class="embedClass" xlink:href="ezcontent://601" xml:id="id3_idm106"><ezlink ezxhtml:class="linkClass" xlink:href="ezcontent://106" xlink:show="new" xlink:title="Link title" xml:id="ezlinkembeddup_idm107"/></ezembedinline></para>
+    <eztemplate name="factoidbox" ezxhtml:align="center" ezxhtml:class="templateClass4" xml:id="ipsum"/>
+    <eztemplate name="factoidbox" ezxhtml:align="center" ezxhtml:class="templateClass4" xml:id="template"/>
+    <eztemplate name="factoidbox" ezxhtml:align="center" ezxhtml:class="templateClass4" xml:id="templatedup_idm110"/>
+    <eztemplate name="factoidbox" ezxhtml:align="center" ezxhtml:class="templateClass4" xml:id="templatedup_idm111"/>
+    <para>Some <eztemplateinline name="emojicake"/> for the otherwise unremarkable paragraph.</para>
+</section>

--- a/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/010-duplicatedIds.xhtml5.edit.xml
+++ b/tests/lib/eZ/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/010-duplicatedIds.xhtml5.edit.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+    <p id="lipsum">Lorem ipsum</p>
+    <p id="lipsum">Nunc in dignissim ex</p>
+    <pre id="lipsum">Literal with CNAME end sequence here : ]]&gt; and some more text here</pre>
+    <pre id="programlisting">Literal with CNAME end sequence here : ]]&gt; and some more text here</pre>
+    <pre id="programlistingdup">Literal with CNAME end sequence here : ]]&gt; and some more text here</pre>
+    <pre id="programlistingdup">Literal with CNAME end sequence here : ]]&gt; and some more text here</pre>
+    <p>The anchor element<a id="lipsum"/> is empty and contributes nothing to the flow of the content in which it occurs. It is only useful as a target.</p>
+    <p>The anchor element<a id="anchor"/> is empty and contributes nothing to the flow of the content in which it occurs. It is only useful as a target.</p>
+    <p>The anchor element<a id="anchordup"/> is empty and contributes nothing to the flow of the content in which it occurs. It is only useful as a target.</p>
+    <p>The anchor element<a id="anchordup"/> is empty and contributes nothing to the flow of the content in which it occurs. It is only useful as a target.</p>
+    <p><a href="#anchor" target="_blank" id="lipsum" title="Anchor link title" class="linkClass1">Jump to content</a></p>
+    <p><a href="#anchor" target="_blank" id="link" title="Anchor link title" class="linkClass1">Jump to content</a></p>
+    <p><a href="#anchor" target="_blank" id="linkdup" title="Anchor link title" class="linkClass1">Jump to content</a></p>
+    <p><a href="#anchor" target="_blank" id="linkdup" title="Anchor link title" class="linkClass1">Jump to content</a></p>
+    <h1 class="titleClass" id="lipsum">This is a heading.</h1>
+    <h1 class="titleClass" id="title">This is a heading.</h1>
+    <h1 class="titleClass" id="titledup">This is a heading.</h1>
+    <h1 class="titleClass" id="titledup">This is a heading.</h1>
+    <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="lipsum">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item 2.</li>
+    </ol>
+    <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="orderedlist">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item 2.</li>
+    </ol>
+    <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="orderedlistdup">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item 2.</li>
+    </ol>
+    <ol class="orderedListClass" data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="orderedlistdup">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item 2.</li>
+    </ol>
+    <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="lipsum">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item 2.</li>
+    </ul>
+    <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="itemizedList">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item 2.</li>
+    </ul>
+    <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="itemizedListdup">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item 2.</li>
+    </ul>
+    <ul data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezattribute-name-3="value 3" id="itemizedListdup">
+        <li class="listItemClass" data-ezattribute-name-2="value 2">This is a list item.</li>
+        <li class="listItemClass" data-ezattribute-name-3="value 3">This is a list item 2.</li>
+    </ul>
+    <table class="tableClass" title="tableTitle" style="width:24%;" id="lipsum">
+        <caption>Table caption.</caption>
+        <tbody>
+            <tr class="rowClass1">
+                <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
+                <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
+            </tr>
+        </tbody>
+    </table>
+    <table class="tableClass" title="tableTitle" style="width:24%;" id="table">
+        <caption>Table caption.</caption>
+        <tbody>
+            <tr class="rowClass1">
+                <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
+                <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
+            </tr>
+        </tbody>
+    </table>
+    <table class="tableClass" title="tableTitle" style="width:24%;" id="tabledup">
+        <caption>Table caption.</caption>
+        <tbody>
+            <tr class="rowClass1">
+                <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
+                <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
+            </tr>
+        </tbody>
+    </table>
+    <table class="tableClass" title="tableTitle" style="width:24%;" id="tabledup">
+        <caption>Table caption.</caption>
+        <tbody>
+            <tr class="rowClass1">
+                <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
+                <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
+            </tr>
+        </tbody>
+    </table>
+    <div data-ezelement="ezembed" data-href="ezlocation://601" id="lipsum" data-ezview="line" class="embedClass2" data-ezalign="right"/>
+    <div data-ezelement="ezembed" data-href="ezlocation://601" id="embed" data-ezview="line" class="embedClass2" data-ezalign="right"/>
+    <div data-ezelement="ezembed" data-href="ezlocation://601" id="embeddup" data-ezview="line" class="embedClass2" data-ezalign="right"/>
+    <div data-ezelement="ezembed" data-href="ezlocation://601" id="embeddup" data-ezview="line" class="embedClass2" data-ezalign="right"/>
+    <p>Some<span data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembedinline" id="lipsum" data-href="ezcontent://601">oe-upcast-placeholder</span> content.</p>
+    <p>Some<span data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembedinline" id="embedInline" data-href="ezcontent://601">oe-upcast-placeholder</span> content.</p>
+    <p>Some<span data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembedinline" id="embedInlinedup" data-href="ezcontent://601">oe-upcast-placeholder</span> content.</p>
+    <p>Some<span data-ezattribute-name-1="value 1" data-ezattribute-name-2="value 2" data-ezelement="ezembedinline" id="embedInlinedup" data-href="ezcontent://601">oe-upcast-placeholder</span> content.</p>
+    <div itemscope="itemscope" data-ezelement="ezembed" data-href="ezlocation://601" a-ezview="line" class="embedClass2" data-ezalign="right">
+        <a data-ezelement="ezlink" href="ezlocation://202" class="linkClass2" id="lipsum" > </a>
+    </div>
+    <div itemscope="itemscope" data-ezelement="ezembed" data-href="ezlocation://601" a-ezview="line" class="embedClass2" data-ezalign="right">
+        <a data-ezelement="ezlink" href="ezlocation://202" class="linkClass2" id="ezlink" > </a>
+    </div>
+    <div itemscope="itemscope" data-ezelement="ezembed" data-href="ezlocation://601" a-ezview="line" class="embedClass2" data-ezalign="right">
+        <a data-ezelement="ezlink" href="ezlocation://202" class="linkClass2" id="ezlinkdup" > </a>
+    </div>
+    <div itemscope="itemscope" data-ezelement="ezembed" data-href="ezlocation://601" a-ezview="line" class="embedClass2" data-ezalign="right">
+        <a data-ezelement="ezlink" href="ezlocation://202" class="linkClass2" id="ezlinkdup" > </a>
+    </div>
+    <p>Some <span itemscope="itemscope" data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">
+        <a data-ezelement="ezlink" href="ezcontent://106" id="lipsum" target="_blank" title="Link title" class="linkClass"> </a></span></p>
+    <p>Some <span itemscope="itemscope" data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">
+        <a data-ezelement="ezlink" href="ezcontent://106" id="ezlinkembed" target="_blank" title="Link title" class="linkClass"> </a></span></p>
+    <p>Some <span itemscope="itemscope" data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">
+        <a data-ezelement="ezlink" href="ezcontent://106" id="ezlinkembeddup" target="_blank" title="Link title" class="linkClass"> </a></span></p>
+    <p>Some <span itemscope="itemscope" data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">
+        <a data-ezelement="ezlink" href="ezcontent://106" id="ezlinkembeddup" target="_blank" title="Link title" class="linkClass"> </a></span></p>
+    <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass4" data-ezalign="center" id="ipsum"/>
+    <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass4" data-ezalign="center" id="template"/>
+    <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass4" data-ezalign="center" id="templatedup"/>
+    <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass4" data-ezalign="center" id="templatedup"/>
+    <p>Some <span data-ezelement="eztemplateinline" data-ezname="emojicake" id="foo"/> for the otherwise unremarkable paragraph.</p>
+</section>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-8258](https://jira.ez.no/browse/IBX-8258)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 3.3
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

XSLT stylesheet doesn't check if ids are unique. I wasn't able to reproduce the problem reported in [IBX-8258](https://jira.ez.no/browse/IBX-8258) with the alloy editor ( IDs are note included in the cut&paste operation when performed on Alloy it seems). It is reproducable on the CKEditor in 4.6
The problem is nevertheless represented in the XSLT stylesheet in 3.3 as well

Note: When merging to 4.6, remember to adopt for changes in XML namespaces in new fixtures

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
